### PR TITLE
fix: remove Promise.reject

### DIFF
--- a/packages/evmos-wallet/src/internal/wallet/functionality/signing.ts
+++ b/packages/evmos-wallet/src/internal/wallet/functionality/signing.ts
@@ -142,11 +142,11 @@ export async function broadcastSignedTxToGRPC(
 
     // Error
     if (response.tx_response.code !== 0) {
-      return Promise.reject({
+      return {
         error: true,
         message: `Transaction Failed ${response.tx_response.raw_log}`,
         txhash: `0x0`,
-      });
+      };
     }
 
     // Success
@@ -156,13 +156,13 @@ export async function broadcastSignedTxToGRPC(
       txhash: response.tx_response.txhash,
     };
   } catch (e) {
-    return Promise.reject({
+    return {
       error: true,
       // Disabled until catching all the possible errors
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       message: `Transaction Failed ${e}`,
       txhash: `0x0`,
-    });
+    };
   }
 }
 
@@ -194,11 +194,11 @@ export async function broadcastEip712BackendTxToBackend(
 
     const response = (await postBroadcast.json()) as BroadcastToBackendResponse;
     if (response.error) {
-      return Promise.reject({
+      return {
         error: true,
         message: `Transaction Failed ${response.error}`,
         txhash: `0x0`,
-      });
+      };
     }
 
     return {
@@ -207,13 +207,13 @@ export async function broadcastEip712BackendTxToBackend(
       txhash: response.tx_hash,
     };
   } catch (e) {
-    return Promise.reject({
+    return {
       error: true,
       // Disabled until catching all the possible errors
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       message: `Transaction Failed ${e}`,
       txhash: `0x0`,
-    });
+    };
   }
 }
 

--- a/packages/evmos-wallet/src/internal/wallet/functionality/signing/genericSigner.ts
+++ b/packages/evmos-wallet/src/internal/wallet/functionality/signing/genericSigner.ts
@@ -234,7 +234,7 @@ export class Signer {
       this.currentExtension === METAMASK_KEY ||
       this.currentExtension === WALLECT_CONNECT_KEY
     ) {
-      if (this.metamaskBackendData == null) {
+      if (this.metamaskBackendData === null) {
         return {
           error: true,
           message: `There is no transaction to be signed`,


### PR DESCRIPTION
This PR removes the Promise.reject so the snackbar is displayed.
The problem was that the return for the signing function was returning a promise and it should only return the information so the snackbar can read it and display it properly. 

Before:

`uncaught (in promise) {error: true, message: 'Transaction Failed Fee changed while sending transaction, please try again', txhash: '0x0'}`

After trying to claim rewards:

![Screenshot 2023-04-24 at 17 35 17](https://user-images.githubusercontent.com/40247040/234045750-6a7f3402-0c93-472e-a465-510078ffd01c.png)
