### PR TITLE
fix: Unify gpvernance card height

### DIFF
--- a/apps/governance/src/components/governance/proposals/ContainerProposals.tsx
+++ b/apps/governance/src/components/governance/proposals/ContainerProposals.tsx
@@ -39,7 +39,7 @@ const ContainerProposals = ({
   }, [proposals, loading, error]);
 
   return (
-    <section className="grid grid-cols-1 gap-4 px-4 md:px-0 lg:grid-cols-2">
+    <section className="grid grid-flow-row grid-cols-1 gap-4 px-4 md:px-0 lg:grid-cols-2">
       {drawProposals()}
     </section>
   );

--- a/apps/governance/src/components/governance/proposals/ProposalCard.tsx
+++ b/apps/governance/src/components/governance/proposals/ProposalCard.tsx
@@ -9,7 +9,7 @@ import TitleContainer from "../common/TitleContainer";
 
 const ProposalCard = ({ proposalProps }: { proposalProps: ProposalProps }) => {
   return (
-    <div className="cursor-pointer space-y-5 rounded-2xl bg-darkGray2 p-5 transition-all h-full justify-between flex flex-col duration-300 hover:bg-darkGray2Opacity">
+    <div className="flex h-full cursor-pointer flex-col justify-between space-y-5 rounded-2xl bg-darkGray2 p-5 transition-all duration-300 hover:bg-darkGray2Opacity">
       <div className="flex justify-between font-[IBM] font-bold text-pearl">
         <IdContainer id={proposalProps.id} />
         <ProposalStatus status={proposalProps.status} />

--- a/apps/governance/src/components/governance/proposals/ProposalCard.tsx
+++ b/apps/governance/src/components/governance/proposals/ProposalCard.tsx
@@ -9,7 +9,7 @@ import TitleContainer from "../common/TitleContainer";
 
 const ProposalCard = ({ proposalProps }: { proposalProps: ProposalProps }) => {
   return (
-    <div className="cursor-pointer space-y-5 rounded-2xl bg-darkGray2 p-5 transition-all duration-300 hover:bg-darkGray2Opacity">
+    <div className="cursor-pointer space-y-5 rounded-2xl bg-darkGray2 p-5 transition-all h-full justify-between flex flex-col duration-300 hover:bg-darkGray2Opacity">
       <div className="flex justify-between font-[IBM] font-bold text-pearl">
         <IdContainer id={proposalProps.id} />
         <ProposalStatus status={proposalProps.status} />


### PR DESCRIPTION
This PR fixes the governance cards height to expand and fill empty spaces

## Before
<img width="1488" alt="Screenshot 2023-04-24 at 12 38 59 PM" src="https://user-images.githubusercontent.com/111534516/234074529-c0c55991-2f75-4190-aadd-7b32065e6691.png">

## After
<img width="1427" alt="Screenshot 2023-04-24 at 12 38 41 PM" src="https://user-images.githubusercontent.com/111534516/234074555-c9b0682a-9e06-4e47-b74d-d9f022e3ff72.png">
