### PR TITLE
feat: add meta tags to each of the pages

### DIFF
--- a/apps/assets/pages/index.tsx
+++ b/apps/assets/pages/index.tsx
@@ -44,7 +44,7 @@ export default function Home() {
               />
               <meta
                 name="keywords"
-                content="assets, evmos, evm, evm on cosmos, fast finality, delegated proof-of-stake, single-token representation, erc20 assets"
+                content="assets, evmos, evm, evm on cosmos, fast finality, delegated proof-of-stake, single-token representation, erc20 assets, (new) evmos dApp"
               />
               <link rel="canonical" href="https://app.evmos.org/assets" />
 
@@ -68,12 +68,12 @@ export default function Home() {
               {/* <!--  Non-Essential, But Recommended --> */}
               <meta
                 property="og:description"
-                content="EVMOS Assets is the official place to withdraw, deposit and convert your Evmos assets."
+                content="Evmos Assets is the official Evmos dApp to withdraw, deposit and convert your Evmos assets."
               />
               <meta property="og:site_name" content="Evmos Assets" />
               <meta
                 name="twitter:description"
-                content="EVMOS Assets is the official place to withdraw, deposit and convert your Evmos assets."
+                content="Evmos Assets is the official Evmos dApp to withdraw, deposit and convert your Evmos assets."
               />
               <meta name="twitter:site" content="@EvmosOrg" />
 

--- a/apps/assets/pages/index.tsx
+++ b/apps/assets/pages/index.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import Head from "next/head";
 import AssetsTable from "../src/components/asset/table/AssetsTable";
 
 import {
@@ -21,6 +20,7 @@ import { Provider, useDispatch, useSelector } from "react-redux";
 import Script from "next/script";
 
 import { StatefulHeader } from "../src/StatefulHeader";
+import { HeadComponent } from "../src/components/asset/HeadComponent";
 function SnackbarsInternal() {
   const valueRedux = useSelector((state: StoreType) => getAllSnackbars(state));
   const dispatch = useDispatch();
@@ -33,54 +33,7 @@ export default function Home() {
       <QueryClientProvider client={queryClient}>
         <WagmiConfig client={wagmiClient}>
           <>
-            <Head>
-              <title>Assets Page</title>
-              <link rel="icon" href="/favicon.ico" />
-
-              <meta charSet="utf-8" />
-              <meta
-                name="viewport"
-                content="width=device-width, initial-scale=1"
-              />
-              <meta
-                name="keywords"
-                content="assets, evmos, evm, evm on cosmos, fast finality, delegated proof-of-stake, single-token representation, erc20 assets, (new) evmos dApp"
-              />
-              <link rel="canonical" href="https://app.evmos.org/assets" />
-
-              {/* <!--  Essential META Tags --> */}
-              <meta property="og:title" content="Evmos Assets" />
-              <meta property="og:type" content="article" />
-              <meta
-                property="og:image"
-                content="https://storage.evmos.org/social_previews/social_share_apps.jpg"
-              />
-              <meta
-                name="twitter:image"
-                property="og:image"
-                content={
-                  "https://storage.evmos.org/social_previews/social_share_apps.jpg"
-                }
-              />
-              <meta property="og:url" content="https://app.evmos.org/assets" />
-              <meta name="twitter:card" content="summary_large_image" />
-
-              {/* <!--  Non-Essential, But Recommended --> */}
-              <meta
-                property="og:description"
-                content="Evmos Assets is the official Evmos dApp to withdraw, deposit and convert your Evmos assets."
-              />
-              <meta property="og:site_name" content="Evmos Assets" />
-              <meta
-                name="twitter:description"
-                content="Evmos Assets is the official Evmos dApp to withdraw, deposit and convert your Evmos assets."
-              />
-              <meta name="twitter:site" content="@EvmosOrg" />
-
-              <link rel="icon" href="/favicon.ico" />
-              {/* <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" /> */}
-              <link rel="manifest" href="/manifest.json" />
-            </Head>
+            <HeadComponent />
             {/* Google tag (gtag.js)  */}
             <Script
               id="google-analytics"

--- a/apps/assets/src/components/asset/HeadComponent.tsx
+++ b/apps/assets/src/components/asset/HeadComponent.tsx
@@ -1,0 +1,53 @@
+import Head from "next/head";
+
+export const HeadComponent = () => {
+  return (
+    <>
+      <Head>
+        <title>Assets Page</title>
+        <link rel="icon" href="/favicon.ico" />
+
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta
+          name="keywords"
+          content="assets, evmos, evm, evm on cosmos, fast finality, delegated proof-of-stake, single-token representation, erc20 assets, (new) evmos dApp"
+        />
+        <link rel="canonical" href="https://app.evmos.org/assets" />
+
+        {/* <!--  Essential META Tags --> */}
+        <meta property="og:title" content="Evmos Assets" />
+        <meta property="og:type" content="article" />
+        <meta
+          property="og:image"
+          content="https://storage.evmos.org/social_previews/social_share_apps.jpg"
+        />
+        <meta
+          name="twitter:image"
+          property="og:image"
+          content={
+            "https://storage.evmos.org/social_previews/social_share_apps.jpg"
+          }
+        />
+        <meta property="og:url" content="https://app.evmos.org/assets" />
+        <meta name="twitter:card" content="summary_large_image" />
+
+        {/* <!--  Non-Essential, But Recommended --> */}
+        <meta
+          property="og:description"
+          content="Evmos Assets is the official Evmos dApp to withdraw, deposit and convert your Evmos assets."
+        />
+        <meta property="og:site_name" content="Evmos Assets" />
+        <meta
+          name="twitter:description"
+          content="Evmos Assets is the official Evmos dApp to withdraw, deposit and convert your Evmos assets."
+        />
+        <meta name="twitter:site" content="@EvmosOrg" />
+
+        <link rel="icon" href="/favicon.ico" />
+        {/* <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" /> */}
+        <link rel="manifest" href="/manifest.json" />
+      </Head>
+    </>
+  );
+};

--- a/apps/governance/pages/index.tsx
+++ b/apps/governance/pages/index.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
 
 import dynamic from "next/dynamic";
-import Head from "next/head";
 import { WagmiConfig } from "wagmi";
 import { Provider, useDispatch, useSelector } from "react-redux";
 
@@ -28,6 +27,7 @@ function SnackbarsInternal() {
   return <Snackbars valueRedux={valueRedux} dispatch={dispatch} />;
 }
 import { StatefulHeader } from "../src/components/StatefulHeader";
+import { HeadComponent } from "../src/components/governance/HeadComponent";
 const Content = dynamic(() => import("../src/components/governance/Content"));
 
 export default function Home() {
@@ -37,59 +37,7 @@ export default function Home() {
       <QueryClientProvider client={queryClient}>
         <WagmiConfig client={wagmiClient}>
           <>
-            <Head>
-              <title>Governance Page</title>
-              <link rel="icon" href="/favicon.ico" />
-
-              <meta charSet="utf-8" />
-              <meta
-                name="viewport"
-                content="width=device-width, initial-scale=1"
-              />
-              <meta
-                name="keywords"
-                content="evmos, evmos dApp, voting, governance, proposal"
-              />
-              <link rel="canonical" href="https://app.evmos.org/governance" />
-
-              {/* <!--  Essential META Tags --> */}
-              <meta property="og:title" content="Evmos Governance" />
-              <meta property="og:type" content="article" />
-
-              <meta
-                property="og:image"
-                content="https://storage.evmos.org/social_previews/social_share_apps.jpg"
-              />
-              <meta
-                name="twitter:image"
-                property="og:image"
-                content={
-                  "https://storage.evmos.org/social_previews/social_share_apps.jpg"
-                }
-              />
-              <meta
-                property="og:url"
-                content="https://app.evmos.org/governance"
-              />
-              <meta name="twitter:card" content="summary_large_image" />
-
-              {/* <!--  Non-Essential, But Recommended --> */}
-              <meta
-                property="og:description"
-                content="Evmos Governance is the official Evmos dApp to view and vote on Evmos governance proposals."
-              />
-              <meta property="og:site_name" content="Evmos Governance" />
-              <meta
-                name="twitter:description"
-                content="Evmos Governance is the official Evmos dApp to view and vote on Evmos governance proposals."
-              />
-              <meta name="twitter:site" content="@EvmosOrg" />
-
-              <link rel="icon" href="/favicon.ico" />
-              {/* <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" /> */}
-              <link rel="manifest" href="/manifest.json" />
-            </Head>
-
+            <HeadComponent />
             <main>
               <TermOfServices />
               <Container>

--- a/apps/governance/pages/index.tsx
+++ b/apps/governance/pages/index.tsx
@@ -49,7 +49,7 @@ export default function Home() {
               {/* TODO: what keywords do we want for governance ? */}
               <meta
                 name="keywords"
-                content="assets, evmos, evm, evm on cosmos, fast finality, delegated proof-of-stake, single-token representation, erc20 assets"
+                content="evmos, evmos dApp, voting, governance, proposal"
               />
               <link rel="canonical" href="https://app.evmos.org/governance" />
 
@@ -78,13 +78,13 @@ export default function Home() {
               {/* TODO: update description */}
               <meta
                 property="og:description"
-                content="EVMOS Assets is the official place to withdraw, deposit and convert your Evmos assets."
+                content="Evmos Governance is the official Evmos dApp to view and vote on Evmos governance proposals."
               />
               <meta property="og:site_name" content="Evmos Governance" />
               {/* TODO: update description */}
               <meta
                 name="twitter:description"
-                content="EVMOS Assets is the official place to withdraw, deposit and convert your Evmos assets."
+                content="Evmos Governance is the official Evmos dApp to view and vote on Evmos governance proposals."
               />
               <meta name="twitter:site" content="@EvmosOrg" />
 

--- a/apps/governance/pages/index.tsx
+++ b/apps/governance/pages/index.tsx
@@ -40,6 +40,57 @@ export default function Home() {
             <Head>
               <title>Governance Page</title>
               <link rel="icon" href="/favicon.ico" />
+
+              <meta charSet="utf-8" />
+              <meta
+                name="viewport"
+                content="width=device-width, initial-scale=1"
+              />
+              {/* TODO: what keywords do we want for governance ? */}
+              <meta
+                name="keywords"
+                content="assets, evmos, evm, evm on cosmos, fast finality, delegated proof-of-stake, single-token representation, erc20 assets"
+              />
+              <link rel="canonical" href="https://app.evmos.org/governance" />
+
+              {/* <!--  Essential META Tags --> */}
+              <meta property="og:title" content="Evmos Governance" />
+              <meta property="og:type" content="article" />
+
+              <meta
+                property="og:image"
+                content="https://storage.evmos.org/social_previews/social_share_apps.jpg"
+              />
+              <meta
+                name="twitter:image"
+                property="og:image"
+                content={
+                  "https://storage.evmos.org/social_previews/social_share_apps.jpg"
+                }
+              />
+              <meta
+                property="og:url"
+                content="https://app.evmos.org/governance"
+              />
+              <meta name="twitter:card" content="summary_large_image" />
+
+              {/* <!--  Non-Essential, But Recommended --> */}
+              {/* TODO: update description */}
+              <meta
+                property="og:description"
+                content="EVMOS Assets is the official place to withdraw, deposit and convert your Evmos assets."
+              />
+              <meta property="og:site_name" content="Evmos Governance" />
+              {/* TODO: update description */}
+              <meta
+                name="twitter:description"
+                content="EVMOS Assets is the official place to withdraw, deposit and convert your Evmos assets."
+              />
+              <meta name="twitter:site" content="@EvmosOrg" />
+
+              <link rel="icon" href="/favicon.ico" />
+              {/* <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" /> */}
+              <link rel="manifest" href="/manifest.json" />
             </Head>
 
             <main>

--- a/apps/governance/pages/index.tsx
+++ b/apps/governance/pages/index.tsx
@@ -46,7 +46,6 @@ export default function Home() {
                 name="viewport"
                 content="width=device-width, initial-scale=1"
               />
-              {/* TODO: what keywords do we want for governance ? */}
               <meta
                 name="keywords"
                 content="evmos, evmos dApp, voting, governance, proposal"
@@ -75,13 +74,11 @@ export default function Home() {
               <meta name="twitter:card" content="summary_large_image" />
 
               {/* <!--  Non-Essential, But Recommended --> */}
-              {/* TODO: update description */}
               <meta
                 property="og:description"
                 content="Evmos Governance is the official Evmos dApp to view and vote on Evmos governance proposals."
               />
               <meta property="og:site_name" content="Evmos Governance" />
-              {/* TODO: update description */}
               <meta
                 name="twitter:description"
                 content="Evmos Governance is the official Evmos dApp to view and vote on Evmos governance proposals."

--- a/apps/governance/src/components/governance/HeadComponent.tsx
+++ b/apps/governance/src/components/governance/HeadComponent.tsx
@@ -1,0 +1,52 @@
+import Head from "next/head";
+
+export const HeadComponent = () => {
+  return (
+    <Head>
+      <title>Governance Page</title>
+      <link rel="icon" href="/favicon.ico" />
+
+      <meta charSet="utf-8" />
+      <meta name="viewport" content="width=device-width, initial-scale=1" />
+      <meta
+        name="keywords"
+        content="evmos, evmos dApp, voting, governance, proposal"
+      />
+      <link rel="canonical" href="https://app.evmos.org/governance" />
+
+      {/* <!--  Essential META Tags --> */}
+      <meta property="og:title" content="Evmos Governance" />
+      <meta property="og:type" content="article" />
+
+      <meta
+        property="og:image"
+        content="https://storage.evmos.org/social_previews/social_share_apps.jpg"
+      />
+      <meta
+        name="twitter:image"
+        property="og:image"
+        content={
+          "https://storage.evmos.org/social_previews/social_share_apps.jpg"
+        }
+      />
+      <meta property="og:url" content="https://app.evmos.org/governance" />
+      <meta name="twitter:card" content="summary_large_image" />
+
+      {/* <!--  Non-Essential, But Recommended --> */}
+      <meta
+        property="og:description"
+        content="Evmos Governance is the official Evmos dApp to view and vote on Evmos governance proposals."
+      />
+      <meta property="og:site_name" content="Evmos Governance" />
+      <meta
+        name="twitter:description"
+        content="Evmos Governance is the official Evmos dApp to view and vote on Evmos governance proposals."
+      />
+      <meta name="twitter:site" content="@EvmosOrg" />
+
+      <link rel="icon" href="/favicon.ico" />
+      {/* <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" /> */}
+      <link rel="manifest" href="/manifest.json" />
+    </Head>
+  );
+};

--- a/apps/mission/pages/index.tsx
+++ b/apps/mission/pages/index.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
 
 import dynamic from "next/dynamic";
-import Head from "next/head";
 import { Provider, useDispatch, useSelector } from "react-redux";
 import { WagmiConfig } from "wagmi";
 const Web3Modal = dynamic(() =>
@@ -20,6 +19,7 @@ import {
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Container, TermOfServices } from "ui-helpers";
 import MainContainer from "../src/components/mission/MainContainer";
+import { HeadComponent } from "../src/components/mission/HeadComponent";
 
 function SnackbarsInternal() {
   const valueRedux = useSelector((state: StoreType) => getAllSnackbars(state));
@@ -33,56 +33,7 @@ export default function Mission() {
       <QueryClientProvider client={queryClient}>
         <WagmiConfig client={wagmiClient}>
           <>
-            <Head>
-              <title>Mission Control</title>
-              <link rel="icon" href="/favicon.ico" />
-
-              <meta charSet="utf-8" />
-              <meta
-                name="viewport"
-                content="width=device-width, initial-scale=1"
-              />
-              <meta
-                name="keywords"
-                content="evmos, landing page, portfolio, overview, assets, stake, governance, vote"
-              />
-              <link rel="canonical" href="https://app.evmos.org/" />
-
-              {/* <!--  Essential META Tags --> */}
-              <meta property="og:title" content="Evmos Mission Control" />
-              <meta property="og:type" content="article" />
-              <meta
-                property="og:image"
-                content="https://storage.evmos.org/social_previews/social_share_apps.jpg"
-              />
-              <meta
-                name="twitter:image"
-                property="og:image"
-                content={
-                  "https://storage.evmos.org/social_previews/social_share_apps.jpg"
-                }
-              />
-              <meta property="og:url" content="https://app.evmos.org/" />
-              <meta name="twitter:card" content="summary_large_image" />
-
-              {/* <!--  Non-Essential, But Recommended --> */}
-
-              <meta
-                property="og:description"
-                content="Mission Control is the official landing page of Evmos, giving you an overview of your Evmos portfolio and any updates from the Evmos development team."
-              />
-              <meta property="og:site_name" content="Evmos Mission Control" />
-              <meta
-                name="twitter:description"
-                content="Mission Control is the official landing page of Evmos, giving you an overview of your Evmos portfolio and any updates from the Evmos development team."
-              />
-              <meta name="twitter:site" content="@EvmosOrg" />
-
-              <link rel="icon" href="/favicon.ico" />
-              {/* <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" /> */}
-              <link rel="manifest" href="/manifest.json" />
-            </Head>
-
+            <HeadComponent />
             <main>
               <TermOfServices />
               <Container>

--- a/apps/mission/pages/index.tsx
+++ b/apps/mission/pages/index.tsx
@@ -42,7 +42,6 @@ export default function Mission() {
                 name="viewport"
                 content="width=device-width, initial-scale=1"
               />
-              {/* TODO: what keywords do we want for mission control ? */}
               <meta
                 name="keywords"
                 content="evmos, landing page, portfolio, overview, assets, stake, governance, vote"
@@ -67,14 +66,12 @@ export default function Mission() {
               <meta name="twitter:card" content="summary_large_image" />
 
               {/* <!--  Non-Essential, But Recommended --> */}
-              {/* TODO: update description */}
 
               <meta
                 property="og:description"
                 content="Mission Control is the official landing page of Evmos, giving you an overview of your Evmos portfolio and any updates from the Evmos development team."
               />
               <meta property="og:site_name" content="Evmos Mission Control" />
-              {/* TODO: update description */}
               <meta
                 name="twitter:description"
                 content="Mission Control is the official landing page of Evmos, giving you an overview of your Evmos portfolio and any updates from the Evmos development team."

--- a/apps/mission/pages/index.tsx
+++ b/apps/mission/pages/index.tsx
@@ -45,7 +45,7 @@ export default function Mission() {
               {/* TODO: what keywords do we want for mission control ? */}
               <meta
                 name="keywords"
-                content="assets, evmos, evm, evm on cosmos, fast finality, delegated proof-of-stake, single-token representation, erc20 assets"
+                content="evmos, landing page, portfolio, overview, assets, stake, governance, vote"
               />
               <link rel="canonical" href="https://app.evmos.org/" />
 
@@ -71,13 +71,13 @@ export default function Mission() {
 
               <meta
                 property="og:description"
-                content="EVMOS Assets is the official place to withdraw, deposit and convert your Evmos assets."
+                content="Mission Control is the official landing page of Evmos, giving you an overview of your Evmos portfolio and any updates from the Evmos development team."
               />
               <meta property="og:site_name" content="Evmos Mission Control" />
               {/* TODO: update description */}
               <meta
                 name="twitter:description"
-                content="EVMOS Assets is the official place to withdraw, deposit and convert your Evmos assets."
+                content="Mission Control is the official landing page of Evmos, giving you an overview of your Evmos portfolio and any updates from the Evmos development team."
               />
               <meta name="twitter:site" content="@EvmosOrg" />
 

--- a/apps/mission/pages/index.tsx
+++ b/apps/mission/pages/index.tsx
@@ -36,6 +36,54 @@ export default function Mission() {
             <Head>
               <title>Mission Control</title>
               <link rel="icon" href="/favicon.ico" />
+
+              <meta charSet="utf-8" />
+              <meta
+                name="viewport"
+                content="width=device-width, initial-scale=1"
+              />
+              {/* TODO: what keywords do we want for mission control ? */}
+              <meta
+                name="keywords"
+                content="assets, evmos, evm, evm on cosmos, fast finality, delegated proof-of-stake, single-token representation, erc20 assets"
+              />
+              <link rel="canonical" href="https://app.evmos.org/" />
+
+              {/* <!--  Essential META Tags --> */}
+              <meta property="og:title" content="Evmos Mission Control" />
+              <meta property="og:type" content="article" />
+              <meta
+                property="og:image"
+                content="https://storage.evmos.org/social_previews/social_share_apps.jpg"
+              />
+              <meta
+                name="twitter:image"
+                property="og:image"
+                content={
+                  "https://storage.evmos.org/social_previews/social_share_apps.jpg"
+                }
+              />
+              <meta property="og:url" content="https://app.evmos.org/" />
+              <meta name="twitter:card" content="summary_large_image" />
+
+              {/* <!--  Non-Essential, But Recommended --> */}
+              {/* TODO: update description */}
+
+              <meta
+                property="og:description"
+                content="EVMOS Assets is the official place to withdraw, deposit and convert your Evmos assets."
+              />
+              <meta property="og:site_name" content="Evmos Mission Control" />
+              {/* TODO: update description */}
+              <meta
+                name="twitter:description"
+                content="EVMOS Assets is the official place to withdraw, deposit and convert your Evmos assets."
+              />
+              <meta name="twitter:site" content="@EvmosOrg" />
+
+              <link rel="icon" href="/favicon.ico" />
+              {/* <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" /> */}
+              <link rel="manifest" href="/manifest.json" />
             </Head>
 
             <main>

--- a/apps/mission/src/components/mission/HeadComponent.tsx
+++ b/apps/mission/src/components/mission/HeadComponent.tsx
@@ -1,0 +1,52 @@
+import Head from "next/head";
+
+export const HeadComponent = () => {
+  return (
+    <Head>
+      <title>Mission Control</title>
+      <link rel="icon" href="/favicon.ico" />
+
+      <meta charSet="utf-8" />
+      <meta name="viewport" content="width=device-width, initial-scale=1" />
+      <meta
+        name="keywords"
+        content="evmos, landing page, portfolio, overview, assets, stake, governance, vote"
+      />
+      <link rel="canonical" href="https://app.evmos.org/" />
+
+      {/* <!--  Essential META Tags --> */}
+      <meta property="og:title" content="Evmos Mission Control" />
+      <meta property="og:type" content="article" />
+      <meta
+        property="og:image"
+        content="https://storage.evmos.org/social_previews/social_share_apps.jpg"
+      />
+      <meta
+        name="twitter:image"
+        property="og:image"
+        content={
+          "https://storage.evmos.org/social_previews/social_share_apps.jpg"
+        }
+      />
+      <meta property="og:url" content="https://app.evmos.org/" />
+      <meta name="twitter:card" content="summary_large_image" />
+
+      {/* <!--  Non-Essential, But Recommended --> */}
+
+      <meta
+        property="og:description"
+        content="Mission Control is the official landing page of Evmos, giving you an overview of your Evmos portfolio and any updates from the Evmos development team."
+      />
+      <meta property="og:site_name" content="Evmos Mission Control" />
+      <meta
+        name="twitter:description"
+        content="Mission Control is the official landing page of Evmos, giving you an overview of your Evmos portfolio and any updates from the Evmos development team."
+      />
+      <meta name="twitter:site" content="@EvmosOrg" />
+
+      <link rel="icon" href="/favicon.ico" />
+      {/* <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" /> */}
+      <link rel="manifest" href="/manifest.json" />
+    </Head>
+  );
+};

--- a/apps/staking/pages/index.tsx
+++ b/apps/staking/pages/index.tsx
@@ -46,7 +46,6 @@ export default function Home() {
                 name="viewport"
                 content="width=device-width, initial-scale=1"
               />
-              {/* TODO: what keywords do we want for staking ? */}
               <meta
                 name="keywords"
                 content="evmos, evmos dApp, staking, validator, delegate, undelegate, unstake, redelegate, rewards"
@@ -71,13 +70,11 @@ export default function Home() {
               <meta name="twitter:card" content="summary_large_image" />
 
               {/* <!--  Non-Essential, But Recommended --> */}
-              {/* TODO: update description */}
               <meta
                 property="og:description"
                 content="Evmos Staking is the official Evmos dApp to stake/unstake your Evmos tokens, claim your rewards, and watch your stake grow."
               />
               <meta property="og:site_name" content="Evmos Staking" />
-              {/* TODO: update description */}
               <meta
                 name="twitter:description"
                 content="Evmos Staking is the official Evmos dApp to stake/unstake your Evmos tokens, claim your rewards, and watch your stake grow."

--- a/apps/staking/pages/index.tsx
+++ b/apps/staking/pages/index.tsx
@@ -49,7 +49,7 @@ export default function Home() {
               {/* TODO: what keywords do we want for staking ? */}
               <meta
                 name="keywords"
-                content="assets, evmos, evm, evm on cosmos, fast finality, delegated proof-of-stake, single-token representation, erc20 assets"
+                content="evmos, evmos dApp, staking, validator, delegate, undelegate, unstake, redelegate, rewards"
               />
               <link rel="canonical" href="https://app.evmos.org/staking" />
 
@@ -74,13 +74,13 @@ export default function Home() {
               {/* TODO: update description */}
               <meta
                 property="og:description"
-                content="EVMOS Assets is the official place to withdraw, deposit and convert your Evmos assets."
+                content="Evmos Staking is the official Evmos dApp to stake/unstake your Evmos tokens, claim your rewards, and watch your stake grow."
               />
               <meta property="og:site_name" content="Evmos Staking" />
               {/* TODO: update description */}
               <meta
                 name="twitter:description"
-                content="EVMOS Assets is the official place to withdraw, deposit and convert your Evmos assets."
+                content="Evmos Staking is the official Evmos dApp to stake/unstake your Evmos tokens, claim your rewards, and watch your stake grow."
               />
               <meta name="twitter:site" content="@EvmosOrg" />
 

--- a/apps/staking/pages/index.tsx
+++ b/apps/staking/pages/index.tsx
@@ -40,6 +40,53 @@ export default function Home() {
             <Head>
               <title>Staking Page</title>
               <link rel="icon" href="/favicon.ico" />
+
+              <meta charSet="utf-8" />
+              <meta
+                name="viewport"
+                content="width=device-width, initial-scale=1"
+              />
+              {/* TODO: what keywords do we want for staking ? */}
+              <meta
+                name="keywords"
+                content="assets, evmos, evm, evm on cosmos, fast finality, delegated proof-of-stake, single-token representation, erc20 assets"
+              />
+              <link rel="canonical" href="https://app.evmos.org/staking" />
+
+              {/* <!--  Essential META Tags --> */}
+              <meta property="og:title" content="Evmos Staking" />
+              <meta property="og:type" content="article" />
+              <meta
+                property="og:image"
+                content="https://storage.evmos.org/social_previews/social_share_apps.jpg"
+              />
+              <meta
+                name="twitter:image"
+                property="og:image"
+                content={
+                  "https://storage.evmos.org/social_previews/social_share_apps.jpg"
+                }
+              />
+              <meta property="og:url" content="https://app.evmos.org/staking" />
+              <meta name="twitter:card" content="summary_large_image" />
+
+              {/* <!--  Non-Essential, But Recommended --> */}
+              {/* TODO: update description */}
+              <meta
+                property="og:description"
+                content="EVMOS Assets is the official place to withdraw, deposit and convert your Evmos assets."
+              />
+              <meta property="og:site_name" content="Evmos Staking" />
+              {/* TODO: update description */}
+              <meta
+                name="twitter:description"
+                content="EVMOS Assets is the official place to withdraw, deposit and convert your Evmos assets."
+              />
+              <meta name="twitter:site" content="@EvmosOrg" />
+
+              <link rel="icon" href="/favicon.ico" />
+              {/* <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" /> */}
+              <link rel="manifest" href="/manifest.json" />
             </Head>
 
             <main>

--- a/apps/staking/pages/index.tsx
+++ b/apps/staking/pages/index.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
 
 import dynamic from "next/dynamic";
-import Head from "next/head";
 import { WagmiConfig } from "wagmi";
 import { Provider, useDispatch, useSelector } from "react-redux";
 
@@ -28,6 +27,7 @@ function SnackbarsInternal() {
   return <Snackbars valueRedux={valueRedux} dispatch={dispatch} />;
 }
 import { StatefulHeader } from "../src/StatefulHeader";
+import { HeadComponent } from "../src/components/staking/HeadComponent";
 const Content = dynamic(() => import("../src/components/staking/Content"));
 
 export default function Home() {
@@ -37,55 +37,7 @@ export default function Home() {
       <QueryClientProvider client={queryClient}>
         <WagmiConfig client={wagmiClient}>
           <>
-            <Head>
-              <title>Staking Page</title>
-              <link rel="icon" href="/favicon.ico" />
-
-              <meta charSet="utf-8" />
-              <meta
-                name="viewport"
-                content="width=device-width, initial-scale=1"
-              />
-              <meta
-                name="keywords"
-                content="evmos, evmos dApp, staking, validator, delegate, undelegate, unstake, redelegate, rewards"
-              />
-              <link rel="canonical" href="https://app.evmos.org/staking" />
-
-              {/* <!--  Essential META Tags --> */}
-              <meta property="og:title" content="Evmos Staking" />
-              <meta property="og:type" content="article" />
-              <meta
-                property="og:image"
-                content="https://storage.evmos.org/social_previews/social_share_apps.jpg"
-              />
-              <meta
-                name="twitter:image"
-                property="og:image"
-                content={
-                  "https://storage.evmos.org/social_previews/social_share_apps.jpg"
-                }
-              />
-              <meta property="og:url" content="https://app.evmos.org/staking" />
-              <meta name="twitter:card" content="summary_large_image" />
-
-              {/* <!--  Non-Essential, But Recommended --> */}
-              <meta
-                property="og:description"
-                content="Evmos Staking is the official Evmos dApp to stake/unstake your Evmos tokens, claim your rewards, and watch your stake grow."
-              />
-              <meta property="og:site_name" content="Evmos Staking" />
-              <meta
-                name="twitter:description"
-                content="Evmos Staking is the official Evmos dApp to stake/unstake your Evmos tokens, claim your rewards, and watch your stake grow."
-              />
-              <meta name="twitter:site" content="@EvmosOrg" />
-
-              <link rel="icon" href="/favicon.ico" />
-              {/* <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" /> */}
-              <link rel="manifest" href="/manifest.json" />
-            </Head>
-
+            <HeadComponent />
             <main>
               <TermOfServices />
               <Container>

--- a/apps/staking/src/components/staking/HeadComponent.tsx
+++ b/apps/staking/src/components/staking/HeadComponent.tsx
@@ -1,0 +1,51 @@
+import Head from "next/head";
+
+export const HeadComponent = () => {
+  return (
+    <Head>
+      <title>Staking Page</title>
+      <link rel="icon" href="/favicon.ico" />
+
+      <meta charSet="utf-8" />
+      <meta name="viewport" content="width=device-width, initial-scale=1" />
+      <meta
+        name="keywords"
+        content="evmos, evmos dApp, staking, validator, delegate, undelegate, unstake, redelegate, rewards"
+      />
+      <link rel="canonical" href="https://app.evmos.org/staking" />
+
+      {/* <!--  Essential META Tags --> */}
+      <meta property="og:title" content="Evmos Staking" />
+      <meta property="og:type" content="article" />
+      <meta
+        property="og:image"
+        content="https://storage.evmos.org/social_previews/social_share_apps.jpg"
+      />
+      <meta
+        name="twitter:image"
+        property="og:image"
+        content={
+          "https://storage.evmos.org/social_previews/social_share_apps.jpg"
+        }
+      />
+      <meta property="og:url" content="https://app.evmos.org/staking" />
+      <meta name="twitter:card" content="summary_large_image" />
+
+      {/* <!--  Non-Essential, But Recommended --> */}
+      <meta
+        property="og:description"
+        content="Evmos Staking is the official Evmos dApp to stake/unstake your Evmos tokens, claim your rewards, and watch your stake grow."
+      />
+      <meta property="og:site_name" content="Evmos Staking" />
+      <meta
+        name="twitter:description"
+        content="Evmos Staking is the official Evmos dApp to stake/unstake your Evmos tokens, claim your rewards, and watch your stake grow."
+      />
+      <meta name="twitter:site" content="@EvmosOrg" />
+
+      <link rel="icon" href="/favicon.ico" />
+      {/* <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" /> */}
+      <link rel="manifest" href="/manifest.json" />
+    </Head>
+  );
+};


### PR DESCRIPTION
This PR adds the meta tags for each of the pages: Mission Control, governance and staking. 
Assets page already has this information. The keywords and description were updated.