### PR TITLE
feat: add google analytics

### DIFF
--- a/apps/assets/pages/index.tsx
+++ b/apps/assets/pages/index.tsx
@@ -89,11 +89,11 @@ export default function Home() {
             />
             <Script id="google-analytics-lz" strategy="lazyOnload">
               {`
-            window.dataLayer = window.dataLayer || [];
-            function gtag(){dataLayer.push(arguments);}
-            gtag('js', new Date());
-            gtag('config', 'G-TBJ303M1SC');
-        `}
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', 'G-TBJ303M1SC');
+              `}
             </Script>
             <main>
               <TermOfServices />

--- a/apps/governance/pages/index.tsx
+++ b/apps/governance/pages/index.tsx
@@ -19,7 +19,7 @@ import {
   getAllSnackbars,
 } from "evmos-wallet";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-
+import Script from "next/script";
 import { TermOfServices, Container, Footer } from "ui-helpers";
 
 function SnackbarsInternal() {
@@ -41,7 +41,19 @@ export default function Home() {
               <title>Governance Page</title>
               <link rel="icon" href="/favicon.ico" />
             </Head>
-
+            <Script
+              id="google-analytics"
+              strategy="lazyOnload"
+              src={`https://www.googletagmanager.com/gtag/js?id=G-TBJ303M1SC`}
+            />
+            <Script id="google-analytics-lz" strategy="lazyOnload">
+              {`
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', 'G-TBJ303M1SC');
+              `}
+            </Script>
             <main>
               <TermOfServices />
               <Container>

--- a/apps/mission/pages/index.tsx
+++ b/apps/mission/pages/index.tsx
@@ -20,6 +20,7 @@ import {
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Container, TermOfServices } from "ui-helpers";
 import MainContainer from "../src/components/mission/MainContainer";
+import Script from "next/script";
 
 function SnackbarsInternal() {
   const valueRedux = useSelector((state: StoreType) => getAllSnackbars(state));
@@ -37,7 +38,20 @@ export default function Mission() {
               <title>Mission Control</title>
               <link rel="icon" href="/favicon.ico" />
             </Head>
-
+            {/* Google tag (gtag.js)  */}
+            <Script
+              id="google-analytics"
+              strategy="lazyOnload"
+              src={`https://www.googletagmanager.com/gtag/js?id=G-TBJ303M1SC`}
+            />
+            <Script id="google-analytics-lz" strategy="lazyOnload">
+              {`
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', 'G-TBJ303M1SC');
+              `}
+            </Script>
             <main>
               <TermOfServices />
               <Container>

--- a/apps/staking/pages/index.tsx
+++ b/apps/staking/pages/index.tsx
@@ -21,6 +21,7 @@ import {
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import { TermOfServices, Footer, Container } from "ui-helpers";
+import Script from "next/script";
 
 function SnackbarsInternal() {
   const valueRedux = useSelector((state: StoreType) => getAllSnackbars(state));
@@ -41,7 +42,20 @@ export default function Home() {
               <title>Staking Page</title>
               <link rel="icon" href="/favicon.ico" />
             </Head>
-
+            {/* Google tag (gtag.js)  */}
+            <Script
+              id="google-analytics"
+              strategy="lazyOnload"
+              src={`https://www.googletagmanager.com/gtag/js?id=G-TBJ303M1SC`}
+            />
+            <Script id="google-analytics-lz" strategy="lazyOnload">
+              {`
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', 'G-TBJ303M1SC');
+              `}
+            </Script>
             <main>
               <TermOfServices />
               <Container>


### PR DESCRIPTION
This PR adds google analytics to the `governance`, `staking`, and `mission` apps