### PR TITLE
feat: add 6 decimals to tokens value

### DIFF
--- a/apps/assets/src/components/asset/modals/common/FromContainer.tsx
+++ b/apps/assets/src/components/asset/modals/common/FromContainer.tsx
@@ -82,15 +82,14 @@ const FromContainer = ({ fee, balance, input, style }: FromProps) => {
         ) && <ErrorMessage text={MODAL_NOTIFICATIONS.ErrorsAmountGt} />}
       <div>
         <span className="font-bold">Balance: </span>
-        {convertAndFormat(balance.amount, balance.decimals)} {style.tokenTo}
+        {convertAndFormat(balance.amount, balance.decimals, 6)} {style.tokenTo}
       </div>
       {!fee.fee.eq(createBigNumber(feeDeposit)) && (
         <div>
           <span className="font-bold">
             Fee denom ({fee.feeDenom}) Balance:{" "}
           </span>
-          {convertAndFormat(fee.feeBalance)}
-          {fee.feeDenom}
+          {convertAndFormat(fee.feeBalance)} {fee.feeDenom}
         </div>
       )}
       {fee.fee.eq(createBigNumber(feeDeposit)) && maxClicked && (

--- a/apps/assets/src/components/asset/modals/common/Tabs.tsx
+++ b/apps/assets/src/components/asset/modals/common/Tabs.tsx
@@ -62,7 +62,7 @@ const Tabs = ({
           />
         </div>
         <span className="text-xs font-normal">
-          {convertAndFormat(erc20Balance, decimals)}
+          {convertAndFormat(erc20Balance, decimals, 6)}
         </span>
       </button>
       <button
@@ -77,7 +77,7 @@ const Tabs = ({
       >
         <span>IBC</span>
         <span className="text-xs font-normal">
-          {convertAndFormat(cosmosBalance, decimals)}
+          {convertAndFormat(cosmosBalance, decimals, 6)}
         </span>
       </button>
     </div>

--- a/apps/assets/src/components/asset/table/ContentTable.tsx
+++ b/apps/assets/src/components/asset/table/ContentTable.tsx
@@ -158,7 +158,7 @@ const ContentTable = ({
             <RowContent
               symbol={v.name}
               imgSrc={`/assets/tokenIdentifier/${v.icon.toLocaleLowerCase()}.png`}
-              valueInTokens={formatNumber(valueInTokens)}
+              valueInTokens={formatNumber(valueInTokens, 6)}
               valueInDollars={valueInDollars.toFixed(2)}
             />
           }

--- a/apps/assets/src/components/asset/table/components/SubRowContent.tsx
+++ b/apps/assets/src/components/asset/table/components/SubRowContent.tsx
@@ -178,7 +178,7 @@ export const SubRowContent = ({
         <div className="mr-8 flex w-full flex-col lg:mr-0">
           {/* displays erc20 balance */}
           <span className="break-all text-sm font-bold">
-            {convertAndFormat(balance, item.decimals)}
+            {convertAndFormat(balance, item.decimals, 6)}
           </span>
           {/* displays ibc balance */}
           <div

--- a/apps/mission/src/components/mission/staking/StakingTable.tsx
+++ b/apps/mission/src/components/mission/staking/StakingTable.tsx
@@ -57,7 +57,7 @@ const StakingTable = ({
               {d.delegation.validator.description.moniker}
             </td>
             <td className="cols-span-1 font-light">
-              {formatNumber(convertFromAtto(d.balance.amount))} EVMOS
+              {formatNumber(convertFromAtto(d.balance.amount), 6)} EVMOS
             </td>
             <td className="cols-span-1 font-light">
               {formatNumber(
@@ -69,7 +69,8 @@ const StakingTable = ({
                         d.delegation.validator_address.toLowerCase()
                     )?.reward[0]?.amount ?? 0
                   )
-                )
+                ),
+                6
               )}{" "}
               EVMOS
             </td>

--- a/apps/mission/src/internal/functionality/hooks/useAssets.tsx
+++ b/apps/mission/src/internal/functionality/hooks/useAssets.tsx
@@ -39,7 +39,7 @@ const useAssets = () => {
           erc20Balance: BigNumber.from(item.erc20Balance),
           decimals: Number(item.decimals),
           cosmosBalance: BigNumber.from(item.cosmosBalance),
-        }).toFixed(2),
+        }).toFixed(6),
         valueInDollars: addDollarAssets({
           erc20Balance: BigNumber.from(item.erc20Balance),
           decimals: Number(item.decimals),

--- a/apps/staking/src/components/staking/AllTabs/Delegations.tsx
+++ b/apps/staking/src/components/staking/AllTabs/Delegations.tsx
@@ -11,7 +11,7 @@ import {
 } from "../../../internal/common/context/SearchContext";
 import { useStakingInfo } from "../../../internal/staking/functionality/hooks/useStakingInfo";
 import { DelegationsResponse } from "../../../internal/staking/functionality/types";
-import { StoreType } from "evmos-wallet";
+import { StoreType, EVMOS_DECIMALS } from "evmos-wallet";
 import { Table } from "../../common/table/Table";
 import {
   tableStyle,
@@ -164,7 +164,11 @@ const Delegations = () => {
             <TdContent
               tdProps={{
                 title: dataHead[3],
-                value: convertAndFormat(BigNumber.from(item.balance.amount)),
+                value: convertAndFormat(
+                  BigNumber.from(item.balance.amount),
+                  EVMOS_DECIMALS,
+                  6
+                ),
               }}
             />
           </td>

--- a/apps/staking/src/components/staking/AllTabs/Undelegations.tsx
+++ b/apps/staking/src/components/staking/AllTabs/Undelegations.tsx
@@ -18,7 +18,7 @@ import {
   trBodyStyle,
 } from "../../common/table/tablesStyles";
 import { TdContent } from "../../common/table/TdContent";
-
+import { EVMOS_DECIMALS } from "evmos-wallet";
 import { convertAndFormat, getRemainingTime } from "helpers";
 import { MessageTable, Modal } from "ui-helpers";
 import { CancelUndelegation } from "../modals/transactions/CancelUndelegation";
@@ -125,7 +125,9 @@ const Undelegations = () => {
               tdProps={{
                 title: dataHead[1],
                 value: `${convertAndFormat(
-                  BigNumber.from(item.balance)
+                  BigNumber.from(item.balance),
+                  EVMOS_DECIMALS,
+                  6
                 )} EVMOS`,
               }}
             />

--- a/apps/staking/src/components/staking/AllTabs/Validators.tsx
+++ b/apps/staking/src/components/staking/AllTabs/Validators.tsx
@@ -15,7 +15,7 @@ import {
 } from "../../../internal/common/context/ValidatorStateContext";
 import { useAllValidators } from "../../../internal/staking/functionality/hooks/useAllValidators";
 import { ValidatorsList } from "../../../internal/staking/functionality/types";
-import { StoreType } from "evmos-wallet";
+import { StoreType, EVMOS_DECIMALS } from "evmos-wallet";
 import { Table } from "../../common/table/Table";
 import {
   tableStyle,
@@ -174,7 +174,9 @@ const Validators = () => {
                 value:
                   item.balance.balance.amount !== ""
                     ? convertAndFormat(
-                        BigNumber.from(item.balance.balance.amount)
+                        BigNumber.from(item.balance.balance.amount),
+                        EVMOS_DECIMALS,
+                        6
                       )
                     : "--",
               }}

--- a/apps/staking/src/components/staking/modals/Staking.tsx
+++ b/apps/staking/src/components/staking/modals/Staking.tsx
@@ -11,6 +11,7 @@ import { Delegate } from "./transactions/Delegate";
 import { Redelegate } from "./transactions/Redelegate";
 import { Undelegate } from "./transactions/Undelegate";
 import { convertAndFormat, formatPercentage } from "helpers";
+import { EVMOS_DECIMALS } from "evmos-wallet";
 
 const Staking = ({
   item,
@@ -57,7 +58,7 @@ const Staking = ({
         )}
         <p>
           {item.balance !== ""
-            ? convertAndFormat(BigNumber.from(item.balance))
+            ? convertAndFormat(BigNumber.from(item.balance), EVMOS_DECIMALS, 6)
             : "0"}{" "}
           EVMOS
         </p>


### PR DESCRIPTION
Problem: the value in tokens for the user is 0.003 but we display 0.00 or 0. That's because we are fixing the numbers with two decimal digits

This PR adds more decimals digits for all the values related to tokens. Instead of 2, we use 6.
You can find these changes:
- Convert modal
- Assets table (assets page)
- Staking table (mission control page)
- Staking table (staking page): Delegations - Undelegations - Validators
- Staking modals (staking page)