### PR TITLE
fix: show connected snackbar only if the user clicks on connect wallet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
-...
+- (bug fixes) #fse-481 | evmos-wallet 1.0.1 | Show connected snackbar only if the user clicks on Connect Wallet
 
 ## 1.0.0 - 2023-04-28
 
-- (chore) #fse-306 | (apps|packages)/\* 1.0.0 | Adding changelog file, updating Licenses and versions in each packages
+- (chore) #fse-306 | apps/_ 1.0.0 packages/_ 1.0.0 | Adding changelog file, updating Licenses and versions in each packages

--- a/packages/evmos-wallet/package.json
+++ b/packages/evmos-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evmos-wallet",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "sideEffects": [
     "**/*.css"
   ],

--- a/packages/evmos-wallet/src/internal/wallet/functionality/keplr/keplr.tsx
+++ b/packages/evmos-wallet/src/internal/wallet/functionality/keplr/keplr.tsx
@@ -35,6 +35,7 @@ import {
   KEPLR_SUCCESS_MESSAGES,
   ResultMessage,
 } from "../errors";
+import { GetProviderFromLocalStorage } from "../localstorage";
 
 export class Keplr {
   active = false;
@@ -101,6 +102,7 @@ export class Keplr {
   }
 
   async connectHandler() {
+    const providerLocalStorage = GetProviderFromLocalStorage();
     await this.getKeplr();
     if (!window.keplr) {
       this.reset();
@@ -194,6 +196,10 @@ export class Keplr {
         })
       );
       SaveProviderToLocalStorate(KEPLR_KEY);
+      // show the connect snackbar only if the user clicks on connect wallet
+      if (providerLocalStorage === KEPLR_KEY) {
+        return true;
+      }
       NotifySuccess(
         {
           type: SNACKBAR_CONTENT_TYPES.TEXT,

--- a/packages/evmos-wallet/src/internal/wallet/functionality/metamask/metamask.tsx
+++ b/packages/evmos-wallet/src/internal/wallet/functionality/metamask/metamask.tsx
@@ -17,6 +17,7 @@ import {
   ResultMessage,
 } from "../errors";
 import {
+  GetProviderFromLocalStorage,
   RemoveProviderFromLocalStorage,
   SaveProviderToLocalStorate,
 } from "../localstorage";
@@ -78,6 +79,7 @@ export class Metamask {
   }
 
   async connectHandler(addresses: Maybe<string[]>) {
+    const providerLocalStorage = GetProviderFromLocalStorage();
     if (addresses === undefined || addresses === null) {
       this.reset();
       return;
@@ -113,6 +115,11 @@ export class Metamask {
           accountName: null,
         })
       );
+      SaveProviderToLocalStorate(METAMASK_KEY);
+      // show the connect snackbar only if the user clicks on connect wallet
+      if (providerLocalStorage === METAMASK_KEY) {
+        return;
+      }
       NotifySuccess(
         {
           type: SNACKBAR_CONTENT_TYPES.TEXT,

--- a/packages/evmos-wallet/src/wallet/ButtonWalletConnection.tsx
+++ b/packages/evmos-wallet/src/wallet/ButtonWalletConnection.tsx
@@ -164,6 +164,7 @@ export const ButtonWalletConnection = ({
             <button
               className="w-full rounded font-bold uppercase border border-darkPearl hover:bg-grayOpacity p-3 mt-3"
               onClick={() => {
+                RemoveProviderFromLocalStorage();
                 disconnectWallets(dispatch);
                 setShow(false);
                 setIsCopied(false);


### PR DESCRIPTION
Problem: Every time the user goes to a different page on the dashboard, the snackbar keeps coming up saying that my wallet is connected.

With this PR the connected snackbar will only appear if the user clicks on connect wallet button
Changes: 
- Disconnect button: add `RemoveProviderFromLocalStorage`
- Get the provider value from localStorage and compare it with the provider key. If they are the same, the snackbar will not show. 


https://user-images.githubusercontent.com/40247040/235127389-2a709a03-35d2-4af2-a743-adaf01736830.mov

