### PR TITLE
chore: update release version to 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
-## Unreleased
+## 1.0.1 - 2023-05-09
 
 - (workflow) #fse-512 | githug/workflows | Adding codeball
 - (tests) #fse-509 | apps/assets 1.0.2 apps/governance 1.0.2 apps/staking 1.0.2 packages/evmos-wallet 1.0.4 packages/helpers 1.0.2 packages/services 1.0.1 packages/ui-helpers 1.0.1 | Adding shared package for jest related configuration

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evmos-apps",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "SEE LICENSE IN LICENSE",
   "author": "Tharsis Labs Ltd.(Evmos)",
   "workspaces": [


### PR DESCRIPTION
This PR simple updates the change log release version and also bumps the main package.json version