### PR TITLE
chore: update release version to 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,10 +36,11 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## UNRELEASED
 
+## 1.0.2 - 2023-05-10
+
 - (workflow) #fse-510 | github actions | Removing unused legacy codeql workflow
 - (chore) #fse-537 | packages/ui-helpers 1.0.2 | Add reusable dismissible announcement banner for DoraHacks
 - (chore) #fse-498 | evmos-wallet 1.0.5 load constant in networkConfig.ts from environment variables & use default fallback values
-
 
 ## 1.0.1 - 2023-05-09
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evmos-apps",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "SEE LICENSE IN LICENSE",
   "author": "Tharsis Labs Ltd.(Evmos)",
   "workspaces": [


### PR DESCRIPTION
This PR simple updates the change log release version and also bumps the main package.json version