### PR TITLE
fix: Change environment variable from NODE_ENV to EVMOS_APP_ENV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (workflow) #fse-510 | github actions | Removing unused legacy codeql workflow
 - (chore) #fse-537 | packages/ui-helpers 1.0.2 | Add reusable dismissible announcement banner for DoraHacks
 - (chore) #fse-498 | evmos-wallet 1.0.5 load constant in networkConfig.ts from environment variables & use default fallback values
+- (fix) #fse-503 | (apps|mission) change environment variable to build \_redirects file
 
 ## 1.0.1 - 2023-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,6 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (chore) #fse-537 | packages/ui-helpers 1.0.2 | Add reusable dismissible announcement banner for DoraHacks
 - (chore) #fse-498 | evmos-wallet 1.0.5 load constant in networkConfig.ts from environment variables & use default fallback values
 
-
 ## 1.0.1 - 2023-05-09
 
 - (workflow) #fse-512 | githug/workflows | Adding codeball

--- a/apps/mission/setup-redirects.sh
+++ b/apps/mission/setup-redirects.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "$NODE_ENV" = "production" ]; then
+if [ "$EVMOS_APP_ENV" = "production" ]; then
   cp public/_redirects_prod public/_redirects
 else
   cp public/_redirects_staging public/_redirects

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "private": true,
   "scripts": {
-    "build:production": "NODE_ENV=production turbo run build",
+    "build:production": "EVMOS_APP_ENV=production turbo run build",
     "build": "turbo run build",
     "dev": "turbo run dev",
     "lint": "turbo run lint",


### PR DESCRIPTION
This Pr is an attempt to fix apps retuning 404 when trying to access from mission control