### PR TITLE
feat: add tracker for un/successful transactions 

### DIFF
--- a/apps/assets/src/components/asset/modals/transactions/hooks/useDeposit.ts
+++ b/apps/assets/src/components/asset/modals/transactions/hooks/useDeposit.ts
@@ -28,12 +28,22 @@ import {
   EVMOS_SYMBOL,
   StoreType,
 } from "evmos-wallet";
-import { CLICK_DEPOSIT_CONFIRM_BUTTON, useTracker } from "tracker";
+import {
+  CLICK_DEPOSIT_CONFIRM_BUTTON,
+  useTracker,
+  SUCCESSFUL_TX_DEPOSIT,
+  UNSUCCESSFUL_TX_DEPOSIT,
+} from "tracker";
 export const useDeposit = (useDepositProps: DepositProps) => {
   const wallet = useSelector((state: StoreType) => state.wallet.value);
   const dispatch = useDispatch();
   const { handlePreClickAction } = useTracker(CLICK_DEPOSIT_CONFIRM_BUTTON);
-
+  const { handlePreClickAction: successfulTx } = useTracker(
+    SUCCESSFUL_TX_DEPOSIT
+  );
+  const { handlePreClickAction: unsuccessfulTx } = useTracker(
+    UNSUCCESSFUL_TX_DEPOSIT
+  );
   const handleConfirmButton = async () => {
     handlePreClickAction({
       wallet: wallet?.evmosAddressEthFormat,
@@ -132,6 +142,13 @@ export const useDeposit = (useDepositProps: DepositProps) => {
     );
 
     dispatch(snackExecuteIBCTransfer(res));
+    if (res.error) {
+      unsuccessfulTx({
+        errorMessage: res.message,
+        wallet: wallet?.evmosAddressEthFormat,
+        provider: wallet?.extensionName,
+      });
+    }
     useDepositProps.setShow(false);
     // check if tx is executed
     if (res.title === BROADCASTED_NOTIFICATIONS.SuccessTitle) {
@@ -150,6 +167,11 @@ export const useDeposit = (useDepositProps: DepositProps) => {
           chainIds.chainIdentifier.toUpperCase()
         )
       );
+      successfulTx({
+        txHash: res.txHash,
+        wallet: wallet?.evmosAddressEthFormat,
+        provider: wallet?.extensionName,
+      });
     }
   };
 

--- a/apps/assets/src/components/asset/modals/transactions/hooks/useWithdraw.ts
+++ b/apps/assets/src/components/asset/modals/transactions/hooks/useWithdraw.ts
@@ -21,13 +21,23 @@ import {
   EVMOS_SYMBOL,
   StoreType,
 } from "evmos-wallet";
-import { CLICK_WITHDRAW_CONFIRM_BUTTON, useTracker } from "tracker";
+import {
+  CLICK_WITHDRAW_CONFIRM_BUTTON,
+  useTracker,
+  SUCCESSFUL_TX_WITHDRAW,
+  UNSUCCESSFUL_TX_WITHDRAW,
+} from "tracker";
 
 export const useWithdraw = (useWithdrawProps: WithdrawProps) => {
   const wallet = useSelector((state: StoreType) => state.wallet.value);
   const dispatch = useDispatch();
   const { handlePreClickAction } = useTracker(CLICK_WITHDRAW_CONFIRM_BUTTON);
-
+  const { handlePreClickAction: successfulTx } = useTracker(
+    SUCCESSFUL_TX_WITHDRAW
+  );
+  const { handlePreClickAction: unsuccessfulTx } = useTracker(
+    UNSUCCESSFUL_TX_WITHDRAW
+  );
   const handleConfirmButton = async () => {
     handlePreClickAction({
       wallet: wallet?.evmosAddressEthFormat,
@@ -116,6 +126,13 @@ export const useWithdraw = (useWithdrawProps: WithdrawProps) => {
     );
 
     dispatch(snackExecuteIBCTransfer(res));
+    if (res.error) {
+      unsuccessfulTx({
+        errorMessage: res.message,
+        wallet: wallet?.evmosAddressEthFormat,
+        provider: wallet?.extensionName,
+      });
+    }
     useWithdrawProps.setShow(false);
     // check if tx is executed
     if (res.title === BROADCASTED_NOTIFICATIONS.SuccessTitle) {
@@ -128,6 +145,11 @@ export const useWithdraw = (useWithdrawProps: WithdrawProps) => {
         )
       );
       dispatch(await snackbarExecutedTx(res.txHash, EVMOS_SYMBOL));
+      successfulTx({
+        txHash: res.txHash,
+        wallet: wallet?.evmosAddressEthFormat,
+        provider: wallet?.extensionName,
+      });
     }
   };
   return { handleConfirmButton };

--- a/apps/governance/src/components/governance/modals/hooks/useVote.tsx
+++ b/apps/governance/src/components/governance/modals/hooks/useVote.tsx
@@ -6,13 +6,19 @@ import { executeVote } from "../../../../internal/governance/functionality/trans
 import { optionVoteSelected } from "../../../../internal/governance/functionality/types";
 import { VoteProps } from "../types";
 import { snackExecuteIBCTransfer } from "evmos-wallet";
-import { CLICK_CONFIRM_VOTE_BUTTON } from "tracker";
+import {
+  CLICK_CONFIRM_VOTE_BUTTON,
+  SUCCESSFUL_TX_VOTE,
+  UNSUCCESSFUL_TX_VOTE,
+} from "tracker";
 import { useTracker } from "tracker";
 
 export const useVote = (useVoteProps: VoteProps) => {
   const dispatch = useDispatch();
   const { handlePreClickAction } = useTracker(CLICK_CONFIRM_VOTE_BUTTON);
-
+  const { handlePreClickAction: successfulTx } = useTracker(SUCCESSFUL_TX_VOTE);
+  const { handlePreClickAction: unsuccessfulTx } =
+    useTracker(UNSUCCESSFUL_TX_VOTE);
   const handleConfirmButton = async () => {
     handlePreClickAction({
       wallet: useVoteProps?.wallet?.evmosAddressEthFormat,
@@ -34,6 +40,19 @@ export const useVote = (useVoteProps: VoteProps) => {
 
     const res = await executeVote(useVoteProps.wallet, useVoteProps.id, option);
     dispatch(snackExecuteIBCTransfer(res));
+    if (res.error === true) {
+      unsuccessfulTx({
+        errorMessage: res.message,
+        wallet: useVoteProps.wallet?.evmosAddressEthFormat,
+        provider: useVoteProps.wallet?.extensionName,
+      });
+    } else {
+      successfulTx({
+        txHash: res.txHash,
+        wallet: useVoteProps.wallet?.evmosAddressEthFormat,
+        provider: useVoteProps.wallet?.extensionName,
+      });
+    }
     useVoteProps.setShow(false);
   };
 

--- a/apps/staking/src/components/staking/modals/hooks/useCancelUndelegations.tsx
+++ b/apps/staking/src/components/staking/modals/hooks/useCancelUndelegations.tsx
@@ -7,7 +7,12 @@ import { parseUnits } from "@ethersproject/units";
 import { BigNumber } from "ethers";
 import { snackExecuteIBCTransfer } from "evmos-wallet";
 import { executeCancelUndelegations } from "../../../../internal/staking/functionality/transactions/cancelUndelegations";
-import { CLICK_CONFIRM_CANCEL_UNDELEGATION_BUTTON, useTracker } from "tracker";
+import {
+  CLICK_CONFIRM_CANCEL_UNDELEGATION_BUTTON,
+  useTracker,
+  SUCCESSFUL_TX_CANCEL_UNDELEGATION,
+  UNSUCCESSFUL_TX_CANCEL_UNDELEGATION,
+} from "tracker";
 
 export const useCancelUndelegations = (
   useCancelUndelegationProps: CancelUndelegationsProps
@@ -15,6 +20,12 @@ export const useCancelUndelegations = (
   const dispatch = useDispatch();
   const { handlePreClickAction } = useTracker(
     CLICK_CONFIRM_CANCEL_UNDELEGATION_BUTTON
+  );
+  const { handlePreClickAction: successfulTx } = useTracker(
+    SUCCESSFUL_TX_CANCEL_UNDELEGATION
+  );
+  const { handlePreClickAction: unsuccessfulTx } = useTracker(
+    UNSUCCESSFUL_TX_CANCEL_UNDELEGATION
   );
   //   async
   const handleConfirmButton = async () => {
@@ -48,6 +59,19 @@ export const useCancelUndelegations = (
       useCancelUndelegationProps.item.creationHeight
     );
     dispatch(snackExecuteIBCTransfer(res));
+    if (res.error === true) {
+      unsuccessfulTx({
+        errorMessage: res.message,
+        wallet: useCancelUndelegationProps.wallet?.evmosAddressEthFormat,
+        provider: useCancelUndelegationProps.wallet?.extensionName,
+      });
+    } else {
+      successfulTx({
+        txHash: res.txHash,
+        wallet: useCancelUndelegationProps.wallet?.evmosAddressEthFormat,
+        provider: useCancelUndelegationProps.wallet?.extensionName,
+      });
+    }
     useCancelUndelegationProps.setShow(false);
   };
 

--- a/apps/staking/src/components/staking/modals/hooks/useDelegation.tsx
+++ b/apps/staking/src/components/staking/modals/hooks/useDelegation.tsx
@@ -7,11 +7,22 @@ import { useDispatch } from "react-redux";
 import { snackExecuteIBCTransfer } from "evmos-wallet";
 import { executeDelegate } from "../../../../internal/staking/functionality/transactions/delegate";
 import { DelegateProps } from "../types";
-import { CLICK_BUTTON_CONFIRM_DELEGATE, useTracker } from "tracker";
+import {
+  CLICK_BUTTON_CONFIRM_DELEGATE,
+  useTracker,
+  SUCCESSFUL_TX_DELEGATE,
+  UNSUCCESSFUL_TX_DELEGATE,
+} from "tracker";
 
 export const useDelegation = (useDelegateProps: DelegateProps) => {
   const dispatch = useDispatch();
   const { handlePreClickAction } = useTracker(CLICK_BUTTON_CONFIRM_DELEGATE);
+  const { handlePreClickAction: successfulTx } = useTracker(
+    SUCCESSFUL_TX_DELEGATE
+  );
+  const { handlePreClickAction: unsuccessfulTx } = useTracker(
+    UNSUCCESSFUL_TX_DELEGATE
+  );
   const handleConfirmButton = async () => {
     handlePreClickAction({
       wallet: useDelegateProps?.wallet?.evmosAddressEthFormat,
@@ -41,6 +52,19 @@ export const useDelegation = (useDelegateProps: DelegateProps) => {
     );
 
     dispatch(snackExecuteIBCTransfer(res));
+    if (res.error === true) {
+      unsuccessfulTx({
+        errorMessage: res.message,
+        wallet: useDelegateProps.wallet?.evmosAddressEthFormat,
+        provider: useDelegateProps.wallet?.extensionName,
+      });
+    } else {
+      successfulTx({
+        txHash: res.txHash,
+        wallet: useDelegateProps.wallet?.evmosAddressEthFormat,
+        provider: useDelegateProps.wallet?.extensionName,
+      });
+    }
     useDelegateProps.setShow(false);
   };
   return { handleConfirmButton };

--- a/apps/staking/src/components/staking/modals/hooks/useRedelegation.tsx
+++ b/apps/staking/src/components/staking/modals/hooks/useRedelegation.tsx
@@ -7,11 +7,22 @@ import { parseUnits } from "@ethersproject/units";
 import { BigNumber } from "ethers";
 import { executeRedelegate } from "../../../../internal/staking/functionality/transactions/redelegate";
 import { snackExecuteIBCTransfer } from "evmos-wallet";
-import { CLICK_BUTTON_CONFIRM_REDELEGATE, useTracker } from "tracker";
+import {
+  CLICK_BUTTON_CONFIRM_REDELEGATE,
+  useTracker,
+  SUCCESSFUL_TX_REDELEGATE,
+  UNSUCCESSFUL_TX_REDELEGATE,
+} from "tracker";
 export const useRedelegation = (useRedelegateProps: RedelegateProps) => {
   const dispatch = useDispatch();
 
   const { handlePreClickAction } = useTracker(CLICK_BUTTON_CONFIRM_REDELEGATE);
+  const { handlePreClickAction: successfulTx } = useTracker(
+    SUCCESSFUL_TX_REDELEGATE
+  );
+  const { handlePreClickAction: unsuccessfulTx } = useTracker(
+    UNSUCCESSFUL_TX_REDELEGATE
+  );
   const handleConfirmButton = async () => {
     handlePreClickAction({
       wallet: useRedelegateProps?.wallet?.evmosAddressEthFormat,
@@ -43,6 +54,19 @@ export const useRedelegation = (useRedelegateProps: RedelegateProps) => {
       useRedelegateProps.validatorDst
     );
     dispatch(snackExecuteIBCTransfer(res));
+    if (res.error === true) {
+      unsuccessfulTx({
+        errorMessage: res.message,
+        wallet: useRedelegateProps.wallet?.evmosAddressEthFormat,
+        provider: useRedelegateProps.wallet?.extensionName,
+      });
+    } else {
+      successfulTx({
+        txHash: res.txHash,
+        wallet: useRedelegateProps.wallet?.evmosAddressEthFormat,
+        provider: useRedelegateProps.wallet?.extensionName,
+      });
+    }
     useRedelegateProps.setShow(false);
   };
 

--- a/apps/staking/src/components/staking/modals/hooks/useRewards.tsx
+++ b/apps/staking/src/components/staking/modals/hooks/useRewards.tsx
@@ -6,20 +6,44 @@ import { snackExecuteIBCTransfer } from "evmos-wallet";
 import { executeRewards } from "../../../../internal/staking/functionality/transactions/rewards";
 import { WalletExtension } from "evmos-wallet/src/internal/wallet/functionality/wallet";
 import { useCallback } from "react";
-import { CLICK_CLAIM_REWARDS_TOPBAR, useTracker } from "tracker";
+import {
+  CLICK_CLAIM_REWARDS_TOPBAR,
+  useTracker,
+  SUCCESSFUL_TX_CLAIM_REWARDS,
+  UNSUCCESSFUL_TX_CLAIM_REWARDS,
+} from "tracker";
 
 export const useRewards = (value: WalletExtension, totalRewards: number) => {
   const dispatch = useDispatch();
   const { handlePreClickAction } = useTracker(CLICK_CLAIM_REWARDS_TOPBAR, {
     amount: totalRewards,
   });
+  const { handlePreClickAction: successfulTx } = useTracker(
+    SUCCESSFUL_TX_CLAIM_REWARDS
+  );
+  const { handlePreClickAction: unsuccessfulTx } = useTracker(
+    UNSUCCESSFUL_TX_CLAIM_REWARDS
+  );
   const handleConfirmButton = useCallback(async () => {
     handlePreClickAction({
       wallet: value?.evmosAddressEthFormat,
       provider: value?.extensionName,
     });
     const res = await executeRewards(value);
+    if (res.error === true) {
+      unsuccessfulTx({
+        errorMessage: res.message,
+        wallet: value?.evmosAddressEthFormat,
+        provider: value?.extensionName,
+      });
+    } else {
+      successfulTx({
+        txHash: res.txHash,
+        wallet: value?.evmosAddressEthFormat,
+        provider: value?.extensionName,
+      });
+    }
     dispatch(snackExecuteIBCTransfer(res));
-  }, [dispatch, value, handlePreClickAction]);
+  }, [dispatch, value, handlePreClickAction, unsuccessfulTx, successfulTx]);
   return { handleConfirmButton };
 };

--- a/apps/staking/src/components/staking/modals/hooks/useUndelegations.tsx
+++ b/apps/staking/src/components/staking/modals/hooks/useUndelegations.tsx
@@ -8,10 +8,21 @@ import { BigNumber } from "ethers";
 import { executeUndelegate } from "../../../../internal/staking/functionality/transactions/undelegate";
 import { snackExecuteIBCTransfer } from "evmos-wallet";
 
-import { CLICK_BUTTON_CONFIRM_UNDELEGATE, useTracker } from "tracker";
+import {
+  CLICK_BUTTON_CONFIRM_UNDELEGATE,
+  useTracker,
+  SUCCESSFUL_TX_UNDELEGATE,
+  UNSUCCESSFUL_TX_UNDELEGATE,
+} from "tracker";
 export const useUndelegation = (useUndelegateProps: UndelegateProps) => {
   const dispatch = useDispatch();
   const { handlePreClickAction } = useTracker(CLICK_BUTTON_CONFIRM_UNDELEGATE);
+  const { handlePreClickAction: successfulTx } = useTracker(
+    SUCCESSFUL_TX_UNDELEGATE
+  );
+  const { handlePreClickAction: unsuccessfulTx } = useTracker(
+    UNSUCCESSFUL_TX_UNDELEGATE
+  );
   const handleConfirmButton = async () => {
     handlePreClickAction({
       wallet: useUndelegateProps?.wallet?.evmosAddressEthFormat,
@@ -40,6 +51,19 @@ export const useUndelegation = (useUndelegateProps: UndelegateProps) => {
       amount
     );
     dispatch(snackExecuteIBCTransfer(res));
+    if (res.error === true) {
+      unsuccessfulTx({
+        errorMessage: res.message,
+        wallet: useUndelegateProps.wallet?.evmosAddressEthFormat,
+        provider: useUndelegateProps.wallet?.extensionName,
+      });
+    } else {
+      successfulTx({
+        txHash: res.txHash,
+        wallet: useUndelegateProps.wallet?.evmosAddressEthFormat,
+        provider: useUndelegateProps.wallet?.extensionName,
+      });
+    }
     useUndelegateProps.setShow(false);
   };
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "private": true,
   "scripts": {
     "build:production": "npm run clear-cache && EVMOS_APP_ENV=production turbo run build",
-    "build": "npm run clear-cache && turbo run build",
+    "build": "npm run clear-cache && turbo run build --force --no-cache",
     "dev": "turbo run dev",
     "lint": "turbo run lint",
     "clean": "turbo run clean",

--- a/packages/tracker/src/constants.ts
+++ b/packages/tracker/src/constants.ts
@@ -64,3 +64,28 @@ export const CLICK_COMMONWEALTH_OUTLINK = "Commonwealth outlink";
 export const CLICK_GOVERNANCE_PROPOSAL = "Governance Proposal";
 export const CLICK_VOTE_BUTTON = "Vote button";
 export const CLICK_CONFIRM_VOTE_BUTTON = "Confirm vote button";
+
+// track un/successful transactions
+export const SUCCESSFUL_TX_DEPOSIT = "DEPOSIT -> Successful transaction";
+export const UNSUCCESSFUL_TX_DEPOSIT = "DEPOSIT -> Unsuccessful transaction";
+export const SUCCESSFUL_TX_WITHDRAW = "WITHDRAW -> Successful transaction";
+export const UNSUCCESSFUL_TX_WITHDRAW = "WITHDRAW -> Unsuccessful transaction";
+export const SUCCESSFUL_TX_VOTE = "VOTE -> Successful transaction";
+export const UNSUCCESSFUL_TX_VOTE = "VOTE -> Unsuccessful transaction";
+
+export const SUCCESSFUL_TX_DELEGATE = "DELEGATE -> Successful transaction";
+export const UNSUCCESSFUL_TX_DELEGATE = "DELEGATE -> Unsuccessful transaction";
+export const SUCCESSFUL_TX_UNDELEGATE = "UNDELEGATE -> Successful transaction";
+export const UNSUCCESSFUL_TX_UNDELEGATE =
+  "UNDELEGATE -> Unsuccessful transaction";
+export const SUCCESSFUL_TX_REDELEGATE = "REDELEGATE -> Successful transaction";
+export const UNSUCCESSFUL_TX_REDELEGATE =
+  "REDELEGATE -> Unsuccessful transaction";
+export const SUCCESSFUL_TX_CANCEL_UNDELEGATION =
+  "CANCEL_UNDELEGATION -> Successful transaction";
+export const UNSUCCESSFUL_TX_CANCEL_UNDELEGATION =
+  "CANCEL_UNDELEGATION -> Unsuccessful transaction";
+export const SUCCESSFUL_TX_CLAIM_REWARDS =
+  "CLAIM_REWARDS -> Successful transaction";
+export const UNSUCCESSFUL_TX_CLAIM_REWARDS =
+  "CLAIM_REWARDS -> Unsuccessful transaction";

--- a/packages/tracker/src/index.tsx
+++ b/packages/tracker/src/index.tsx
@@ -50,6 +50,25 @@ export { CLICK_GOVERNANCE_PROPOSAL } from "./constants";
 export { CLICK_VOTE_BUTTON } from "./constants";
 export { CLICK_CONFIRM_VOTE_BUTTON } from "./constants";
 
+// tracker
 export { MixpanelProvider } from "./MixPanelProvider";
 export { useMixpanel } from "./context/mixpanel";
 export { useTracker } from "./useTracker";
+
+// track un/successful transactions
+export { SUCCESSFUL_TX_DEPOSIT } from "./constants";
+export { UNSUCCESSFUL_TX_DEPOSIT } from "./constants";
+export { SUCCESSFUL_TX_WITHDRAW } from "./constants";
+export { UNSUCCESSFUL_TX_WITHDRAW } from "./constants";
+export { SUCCESSFUL_TX_VOTE } from "./constants";
+export { UNSUCCESSFUL_TX_VOTE } from "./constants";
+export { SUCCESSFUL_TX_DELEGATE } from "./constants";
+export { UNSUCCESSFUL_TX_DELEGATE } from "./constants";
+export { SUCCESSFUL_TX_UNDELEGATE } from "./constants";
+export { UNSUCCESSFUL_TX_UNDELEGATE } from "./constants";
+export { SUCCESSFUL_TX_REDELEGATE } from "./constants";
+export { UNSUCCESSFUL_TX_REDELEGATE } from "./constants";
+export { SUCCESSFUL_TX_CANCEL_UNDELEGATION } from "./constants";
+export { UNSUCCESSFUL_TX_CANCEL_UNDELEGATION } from "./constants";
+export { SUCCESSFUL_TX_CLAIM_REWARDS } from "./constants";
+export { UNSUCCESSFUL_TX_CLAIM_REWARDS } from "./constants";

--- a/packages/tracker/src/useTracker.tsx
+++ b/packages/tracker/src/useTracker.tsx
@@ -5,10 +5,11 @@ export const useTracker = (event: string, properties?: Dict) => {
   const mixpanel = useMixpanel();
 
   const handlePreClickAction = (extraProperties?: Dict) => {
-    // if mixpanel is not set, config will not exist. Avoid undefined error adding ?
-    if (mixpanel?.get_config("token")) {
-      // Check that a token was provided (useful if you have environments without Mixpanel)
-      mixpanel?.track(event, { ...properties, ...extraProperties });
+    if (
+      mixpanel !== null &&
+      Object.prototype.hasOwnProperty.call(mixpanel, "get_config")
+    ) {
+      mixpanel.track(event, { ...properties, ...extraProperties });
     }
   };
 


### PR DESCRIPTION
- Add new metrics: un/successful transactions for deposit, withdraw, vote, delegate, undelegate, cancel undelegation, redelegate, claim rewards. https://www.notion.so/Events-to-Track-with-Mixpanel-fa70b600c5604f84a6840a0baf91910b#2c376b4fb98a4dd9925d761315ea5b62
- Fix error `TypeError: cannot read properties of undefined (reading 'token')`. It was appearing if the token was not set.