### PR TITLE
fix: check for config instead of get_config property

### DIFF
--- a/packages/tracker/src/useTracker.tsx
+++ b/packages/tracker/src/useTracker.tsx
@@ -7,7 +7,7 @@ export const useTracker = (event: string, properties?: Dict) => {
   const handlePreClickAction = (extraProperties?: Dict) => {
     if (
       mixpanel !== null &&
-      Object.prototype.hasOwnProperty.call(mixpanel, "get_config")
+      Object.prototype.hasOwnProperty.call(mixpanel, "config")
     ) {
       mixpanel.track(event, { ...properties, ...extraProperties });
     }


### PR DESCRIPTION
Mixpanel was not working because it was trying to find the property get_config instead of config. 