### PR TITLE
chore: Add system error banner for ledger + keplr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## 1.0.7 - 2023-06-01
 
+- (chore) #fse-592 | apps/assets 1.0.10 apps/governance 1.0.9 apps/mission 1.0.9 apps/staking 1.0.9 packages/ui-helpers 1.0.7 | Add system error banner for ledger + keplr
+
 - (fix) #fse-593 | apps/assets 1.0.9 apps/governance 1.0.8 apps/mission 1.0.8 apps/staking 1.0.8 packages/ui-helpers 1.0.6 | Fix consent modal to work in every browser
 - (fix) #fse-592 | Remove Coslend from mission control
 

--- a/apps/assets/package.json
+++ b/apps/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "assets-page",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3002",

--- a/apps/assets/src/components/asset/table/AssetsTable.tsx
+++ b/apps/assets/src/components/asset/table/AssetsTable.tsx
@@ -11,7 +11,12 @@ import { NAV_TO_MISSION_CONTROL, EVMOS_PAGE_URL } from "constants-helper";
 import dynamic from "next/dynamic";
 
 const ModalAsset = dynamic(() => import("../modals/ModalAsset"));
-import { MessageTable, Switch, Navigation } from "ui-helpers";
+import {
+  MessageTable,
+  Switch,
+  Navigation,
+  SystemErrorBanner,
+} from "ui-helpers";
 const TopBar = dynamic(() => import("./topBar/TopBar"));
 const ContentTable = dynamic(() => import("./ContentTable"));
 
@@ -117,6 +122,9 @@ const AssetsTable = () => {
           handlePreClickAction();
         }}
       />
+      <div className="mb-4">
+        <SystemErrorBanner text="We are currently experiencing issues with Ledger-related transactions. We're on it!" />
+      </div>
       <TopBar topProps={topProps} />
       <div className="mx-5 flex flex-col justify-center lg:flex-row lg:justify-between xl:mx-0">
         <Guide />

--- a/apps/governance/package.json
+++ b/apps/governance/package.json
@@ -1,7 +1,7 @@
 {
   "name": "governance-page",
 
-  "version": "1.0.8",
+  "version": "1.0.9",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",

--- a/apps/governance/src/components/governance/Content.tsx
+++ b/apps/governance/src/components/governance/Content.tsx
@@ -11,7 +11,7 @@ import {
   NAV_TO_GOVERNANCE,
   COMMONWEALTH_URL,
 } from "constants-helper";
-import { Navigation } from "ui-helpers";
+import { Navigation, SystemErrorBanner } from "ui-helpers";
 import { CLICK_BACK_TO_MC } from "tracker";
 import { useTracker } from "tracker";
 
@@ -52,6 +52,9 @@ const Content = () => {
   return (
     <div>
       {drawNavigation()}
+      <div className="mb-4">
+        <SystemErrorBanner text="We are currently experiencing issues with Ledger-related transactions. We're on it!" />
+      </div>
       {id === undefined && (
         <BannerBlack
           text="Have you ever wondered where proposals come from? Join us in our open

--- a/apps/mission/package.json
+++ b/apps/mission/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mission-page",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3004",

--- a/apps/mission/src/components/mission/Content.tsx
+++ b/apps/mission/src/components/mission/Content.tsx
@@ -8,7 +8,7 @@ import NewsFeed from "./feeds/NewsFeed";
 import Governance from "./governance/Governance";
 import Staking from "./staking/Staking";
 import EvmosApps from "./apps/EvmosApps";
-
+import { SystemErrorBanner } from "ui-helpers";
 import { CLICK_MISSION_CONTROL_HALF_LIFE, useTracker } from "tracker";
 
 const TopBarMissionControl = dynamic(() => import("./TopBarMissionControl"));
@@ -18,7 +18,11 @@ const Content = () => {
 
   return (
     <div className="flex flex-col pt-4">
+      <div className="mb-4">
+        <SystemErrorBanner text="We are currently experiencing issues with Ledger-related transactions. We're on it!" />
+      </div>
       <TopBarMissionControl />
+
       <div className="mx-5 grid grid-cols-6 gap-6 xl:mx-0">
         <div className="col-span-6 flex flex-col gap-4 lg:col-span-4">
           <Assets />

--- a/apps/staking/package.json
+++ b/apps/staking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "staking-page",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3003",

--- a/apps/staking/src/components/staking/Content.tsx
+++ b/apps/staking/src/components/staking/Content.tsx
@@ -4,7 +4,7 @@
 import dynamic from "next/dynamic";
 import { SearchWrapper } from "../../internal/common/context/SearchContext";
 import { ValidatorStateWrapper } from "../../internal/common/context/ValidatorStateContext";
-import { Navigation } from "ui-helpers";
+import { Navigation, SystemErrorBanner } from "ui-helpers";
 import { tabsContent } from "./Tabs/Content";
 import { NAV_TO_MISSION_CONTROL, EVMOS_PAGE_URL } from "constants-helper";
 const TopBarStaking = dynamic(() => import("./components/TopBarStaking"));
@@ -24,6 +24,9 @@ const Content = () => {
               handlePreClickAction();
             }}
           />
+          <div className="mb-4">
+            <SystemErrorBanner text="We are currently experiencing issues with Ledger-related transactions. We're on it!" />
+          </div>
           <TopBarStaking />
           <div className=" xl:scrollbar-hide mt-5 w-full px-2 font-[IBM] text-pearl">
             <Tabs

--- a/packages/ui-helpers/package.json
+++ b/packages/ui-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui-helpers",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "sideEffects": [
     "**/*.css"
   ],

--- a/packages/ui-helpers/src/SystemErrorBanner.tsx
+++ b/packages/ui-helpers/src/SystemErrorBanner.tsx
@@ -1,0 +1,16 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
+
+export const SystemErrorBanner = ({
+  text,
+}: {
+  text: string | React.ReactNode;
+}) => {
+  return (
+    <div
+      className={`rounded-md text-pearl flex items-center justify-between space-x-2 bg-red p-4 px-5 font-[GreyCliff] font-medium text-black`}
+    >
+      {text}
+    </div>
+  );
+};

--- a/packages/ui-helpers/src/index.tsx
+++ b/packages/ui-helpers/src/index.tsx
@@ -30,3 +30,4 @@ export { BarContainer } from "./votingBar/BarContainer";
 export { Header } from "./Header";
 export { InformationBanner } from "./InformationBanner";
 export { ConsentModal } from "./termsOfServices/ConsentModal";
+export { SystemErrorBanner } from "./SystemErrorBanner";


### PR DESCRIPTION
This PR adds a simple system error banner to inform users Ledger + Keplr is currently not working.

The banner has been added to all apps


Example:
<img width="1512" alt="Screenshot 2023-06-06 at 7 22 21 PM" src="https://github.com/evmos/apps/assets/111534516/c46adbb3-211f-46f4-ac3e-a7b278fa9707">
