### PR TITLE
feat: create modal for vesting accounts

### DIFF
--- a/apps/vesting/src/components/vesting/header/CreateAccountModal.tsx
+++ b/apps/vesting/src/components/vesting/header/CreateAccountModal.tsx
@@ -1,5 +1,5 @@
 import { ModalTitle } from "ui-helpers";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { FieldValues, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 
@@ -36,34 +36,36 @@ export const CreateAccountModal = () => {
 
   const endDate = getEndDate(selectedStartDate, selectedVestingDuration);
 
-  const vestingSettingsConfig = {
-    [PlansType.Team]: {
-      duration: [Duration.FourYears],
-      cliff: [Duration.OneYear],
-      schedule: [Duration.Monthly],
-      lockup: [Duration.OneYear],
-      disabled: true,
-    },
-    [PlansType.Grantee]: {
-      duration: [Duration.OneYear],
-      cliff: [Duration.OneDay],
-      schedule: [Duration.Monthly],
-      lockup: [Duration.OneYear],
-      disabled: true,
-    },
-    [PlansType.Custom]: {
-      duration: [Duration.FourYears, Duration.OneYear],
-      cliff: [
-        Duration.None,
-        Duration.OneYear,
-        Duration.OneMonth,
-        Duration.OneDay,
-      ],
-      schedule: [Duration.Monthly, Duration.Quarterly],
-      lockup: [Duration.None, Duration.OneYear, Duration.OneMonth],
-      disabled: false,
-    },
-  };
+  const vestingSettingsConfig = useMemo(() => {
+    return {
+      [PlansType.Team]: {
+        duration: [Duration.FourYears],
+        cliff: [Duration.OneYear],
+        schedule: [Duration.Monthly],
+        lockup: [Duration.OneYear],
+        disabled: true,
+      },
+      [PlansType.Grantee]: {
+        duration: [Duration.OneYear],
+        cliff: [Duration.OneDay],
+        schedule: [Duration.Monthly],
+        lockup: [Duration.OneYear],
+        disabled: true,
+      },
+      [PlansType.Custom]: {
+        duration: [Duration.FourYears, Duration.OneYear],
+        cliff: [
+          Duration.None,
+          Duration.OneYear,
+          Duration.OneMonth,
+          Duration.OneDay,
+        ],
+        schedule: [Duration.Monthly, Duration.Quarterly],
+        lockup: [Duration.None, Duration.OneYear, Duration.OneMonth],
+        disabled: false,
+      },
+    };
+  }, []);
 
   const DEFAULT_TYPE = vestingSettingsConfig[PlansType.Team];
   const [type, setType] = useState(DEFAULT_TYPE);
@@ -71,6 +73,7 @@ export const CreateAccountModal = () => {
   useEffect(() => {
     setType(vestingSettingsConfig[selectedPlanType]);
   }, [selectedPlanType, vestingSettingsConfig]);
+
   return (
     <div className="space-y-5">
       <ModalTitle title="Create Vesting Account" />
@@ -89,9 +92,10 @@ export const CreateAccountModal = () => {
           id="planType"
           {...register("planType")}
           aria-invalid={Boolean(errors.title)}
+          defaultValue="Team"
         >
           {plans.map((elt) => (
-            <option key={elt} value={elt} selected={elt === "Team"}>
+            <option key={elt} value={elt}>
               {elt}
             </option>
           ))}

--- a/apps/vesting/src/components/vesting/header/CreateAccountModal.tsx
+++ b/apps/vesting/src/components/vesting/header/CreateAccountModal.tsx
@@ -70,7 +70,7 @@ export const CreateAccountModal = () => {
 
   useEffect(() => {
     setType(vestingSettingsConfig[selectedPlanType]);
-  }, [selectedPlanType]);
+  }, [selectedPlanType, vestingSettingsConfig]);
   return (
     <div className="space-y-5">
       <ModalTitle title="Create Vesting Account" />

--- a/apps/vesting/src/components/vesting/header/CreateAccountModal.tsx
+++ b/apps/vesting/src/components/vesting/header/CreateAccountModal.tsx
@@ -1,0 +1,244 @@
+import { ModalTitle } from "ui-helpers";
+import React, { useEffect, useState } from "react";
+import { FieldValues, useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+import { formatNumber } from "helpers";
+import {
+  Duration,
+  PlansType,
+  dummyProps,
+  getEndDate,
+  plans,
+  schema,
+  setVestingAccountNameLocalstorage,
+} from "./helpers";
+
+export const CreateAccountModal = () => {
+  const handleOnClick = (d: FieldValues) => {
+    // TODO: logic for create account modal
+    if (d.accountName !== "") {
+      setVestingAccountNameLocalstorage(d.accountName);
+    }
+  };
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors },
+  } = useForm({
+    resolver: zodResolver(schema),
+  });
+
+  const selectedPlanType: PlansType = watch("planType");
+  const selectedStartDate = watch("startDate");
+  const selectedVestingDuration = watch("vestingDuration");
+
+  const endDate = getEndDate(selectedStartDate, selectedVestingDuration);
+
+  const vestingSettingsConfig = {
+    [PlansType.Team]: {
+      duration: [Duration.FourYears],
+      cliff: [Duration.OneYear],
+      schedule: [Duration.Monthly],
+      lockup: [Duration.OneYear],
+      disabled: true,
+    },
+    [PlansType.Grantee]: {
+      duration: [Duration.OneYear],
+      cliff: [Duration.OneDay],
+      schedule: [Duration.Monthly],
+      lockup: [Duration.OneYear],
+      disabled: true,
+    },
+    [PlansType.Custom]: {
+      duration: [Duration.FourYears, Duration.OneYear],
+      cliff: [
+        Duration.None,
+        Duration.OneYear,
+        Duration.OneMonth,
+        Duration.OneDay,
+      ],
+      schedule: [Duration.Monthly, Duration.Quarterly],
+      lockup: [Duration.None, Duration.OneYear, Duration.OneMonth],
+      disabled: false,
+    },
+  };
+
+  const DEFAULT_TYPE = vestingSettingsConfig[PlansType.Team];
+  const [type, setType] = useState(DEFAULT_TYPE);
+
+  useEffect(() => {
+    setType(vestingSettingsConfig[selectedPlanType]);
+  }, [selectedPlanType]);
+  return (
+    <div className="space-y-5">
+      <ModalTitle title="Create Vesting Account" />
+
+      <form
+        onSubmit={handleSubmit((d) => {
+          // console.log(d);
+          handleOnClick(d);
+        })}
+        className="flex flex-col space-y-3"
+      >
+        <label htmlFor="planType" className="text-xs font-bold">
+          PLAN TYPE
+        </label>
+        <select
+          id="planType"
+          {...register("planType")}
+          aria-invalid={Boolean(errors.title)}
+        >
+          {plans.map((elt) => (
+            <option key={elt} value={elt} selected={elt === "Team"}>
+              {elt}
+            </option>
+          ))}
+        </select>
+
+        <div className="flex items-center justify-between space-x-2">
+          <div className="flex flex-grow flex-col space-y-2">
+            <label htmlFor="vestingDuration" className="text-xs font-bold">
+              VESTING DURATION
+            </label>
+
+            <select
+              id="vestingDuration"
+              {...register("vestingDuration")}
+              aria-invalid={Boolean(errors.title)}
+              disabled={type?.disabled}
+            >
+              {type?.duration.map((elt) => (
+                <option key={elt} value={elt}>
+                  {elt}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex flex-grow flex-col space-y-2">
+            <label htmlFor="vestingCliff" className="text-xs font-bold">
+              VESTING CLIFF
+            </label>
+
+            <select
+              id="vestingCliff"
+              {...register("vestingCliff")}
+              aria-invalid={Boolean(errors.title)}
+              disabled={type?.disabled}
+            >
+              {type?.cliff.map((elt) => (
+                <option key={elt} value={elt}>
+                  {elt}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between space-x-2">
+          <div className="flex flex-grow flex-col space-y-2">
+            <label htmlFor="vestingSchedule" className="text-xs font-bold">
+              VESTING SCHEDULE
+            </label>
+
+            <select
+              id="vestingSchedule"
+              {...register("vestingSchedule")}
+              aria-invalid={Boolean(errors.title)}
+              disabled={type?.disabled}
+            >
+              {type?.schedule.map((elt) => (
+                <option key={elt} value={elt}>
+                  {elt}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex flex-grow flex-col space-y-2">
+            <label htmlFor="lockupDuration" className="text-xs font-bold">
+              LOCKUP DURATION
+            </label>
+
+            <select
+              id="lockupDuration"
+              {...register("lockupDuration")}
+              aria-invalid={Boolean(errors.title)}
+              disabled={type?.disabled}
+            >
+              {type?.lockup.map((elt) => (
+                <option key={elt} value={elt}>
+                  {elt}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+        <div className="flex justify-between">
+          <label htmlFor="startDate" className="text-xs font-bold">
+            START DATE
+          </label>
+          <div className="text-right text-[10px]">
+            {endDate !== undefined && endDate[0] && (
+              <p>END DATE: {endDate[1]}</p>
+            )}
+            <p>(i) The start time will default to 0:00 UTC</p>
+          </div>
+        </div>
+        <input id="startDate" type="date" {...register("startDate")} />
+        {errors.startDate?.message && (
+          <span className="text-xs text-red">
+            {errors.startDate.message.toString()}
+          </span>
+        )}
+
+        <label htmlFor="address" className="text-xs font-bold">
+          ADDRESS
+        </label>
+        <input id="address" {...register("address")} />
+        {errors.address?.message && (
+          <span className="text-xs text-red">
+            {errors.address.message.toString()}
+          </span>
+        )}
+
+        <label
+          htmlFor="accountName"
+          className="v flex justify-between text-xs font-bold"
+        >
+          ACCOUNT NAME
+        </label>
+        <input id="accountName" {...register("accountName")} />
+        {errors.accountName?.message && (
+          <span className="text-xs text-red">
+            {errors.accountName.message.toString()}
+          </span>
+        )}
+
+        <label htmlFor="amount" className="flex justify-between text-xs ">
+          <span className="font-bold">AMOUNT</span>
+          <span>Available: {formatNumber(dummyProps.available)} EVMOS</span>
+        </label>
+        <input
+          type="number"
+          id="amount"
+          {...register("amount", { valueAsNumber: true })}
+        />
+        {errors.amount?.message && (
+          <span className="text-xs text-red">
+            {errors.amount.message.toString()}
+          </span>
+        )}
+
+        <input
+          type="submit"
+          style={{ backgroundColor: "#ed4e33" }}
+          className="w-full cursor-pointer rounded p-2 font-[GreyCliff] text-lg  font-bold uppercase text-pearl"
+          value="Create"
+        />
+      </form>
+    </div>
+  );
+};

--- a/apps/vesting/src/components/vesting/header/Header.tsx
+++ b/apps/vesting/src/components/vesting/header/Header.tsx
@@ -1,14 +1,19 @@
-import { ConfirmButton } from "ui-helpers";
+import { ConfirmButton, Modal } from "ui-helpers";
 import { SearchVesting } from "./SearchVesting";
 import { useSelector } from "react-redux";
 import { StoreType } from "evmos-wallet";
+import { useState } from "react";
+import { CreateAccountModal } from "./CreateAccountModal";
 export const Header = () => {
   const handleConfirmClick = () => {
     // TODO: open modal for creating vesting account
+    setShowModal(true);
+    setModalContent(<CreateAccountModal />);
   };
 
   const value = useSelector((state: StoreType) => state.wallet.value);
-
+  const [showModal, setShowModal] = useState(false);
+  const [modalContent, setModalContent] = useState<JSX.Element>(<></>);
   return (
     <header className="flex w-full flex-col items-center space-y-2 lg:flex-row lg:justify-end lg:space-y-0 lg:space-x-2">
       <SearchVesting />
@@ -18,6 +23,14 @@ export const Header = () => {
         onClick={handleConfirmClick}
         disabled={!value.active}
       />
+      <Modal
+        show={showModal}
+        onClose={() => {
+          setShowModal(false);
+        }}
+      >
+        {modalContent}
+      </Modal>
     </header>
   );
 };

--- a/apps/vesting/src/components/vesting/header/helpers.spec.tsx
+++ b/apps/vesting/src/components/vesting/header/helpers.spec.tsx
@@ -1,0 +1,17 @@
+import { Duration, getEndDate } from "./helpers";
+
+describe("Vesting UI helpers", () => {
+  it("should return true and the end date formatted", () => {
+    const date = "2023-05-01";
+    const vestingDuration = Duration.FourYears;
+    const msg = getEndDate(date, vestingDuration);
+    expect(msg).toStrictEqual([true, "05/01/2027"]);
+  });
+
+  it("should return false and the end date formatted", () => {
+    const date = undefined;
+    const vestingDuration = Duration.FourYears;
+    const msg = getEndDate(date, vestingDuration);
+    expect(msg).toStrictEqual([false, ""]);
+  });
+});

--- a/apps/vesting/src/components/vesting/header/helpers.ts
+++ b/apps/vesting/src/components/vesting/header/helpers.ts
@@ -1,0 +1,90 @@
+// create test
+import * as z from "zod";
+export const getEndDate = (
+  date: string | undefined,
+  vestingDuration: string
+) => {
+  const duration = Number(vestingDuration?.split(" ")[0]);
+  const year = Number(date?.split("-")[0]);
+  if (!isNaN(duration) && !isNaN(year)) {
+    const total = duration + year;
+    const day = date?.split("-")[2];
+    const month = date?.split("-")[1];
+    const finalDate = month + "/" + day + "/" + total;
+    const isSet = month === undefined ? false : true;
+    return [isSet, finalDate];
+  }
+  return [false, ""];
+};
+
+const VESTING_ACCOUNT_NAME_LOCALSTORAGE = "VESTING_ACCOUNT_NAME";
+
+export const setVestingAccountNameLocalstorage = (accountName: string) => {
+  localStorage.setItem(VESTING_ACCOUNT_NAME_LOCALSTORAGE, accountName);
+};
+
+export enum Duration {
+  OneYear = "1 YEAR",
+  FourYears = "4 YEARS",
+  None = "None",
+  OneMonth = "1 MONTH",
+  OneDay = "1 DAY",
+  Monthly = "Monthly",
+  Quarterly = "Quarterly",
+}
+
+export enum PlansType {
+  Team = "Team",
+  Grantee = "Grantee",
+  Custom = "Custom",
+}
+
+export const plans = [
+  PlansType.Custom,
+  PlansType.Team,
+  PlansType.Grantee,
+] as const;
+export const duration = [Duration.FourYears, Duration.OneYear] as const;
+export const cliff = [
+  Duration.None,
+  Duration.OneYear,
+  Duration.OneMonth,
+  Duration.OneDay,
+] as const;
+export const schedule = [Duration.Monthly, Duration.Quarterly] as const;
+export const lockup = [
+  Duration.None,
+  Duration.OneYear,
+  Duration.OneMonth,
+] as const;
+
+export const dummyProps = {
+  available: "2000450.52",
+};
+
+export const schema = z.object({
+  address: z
+    .string()
+    .min(1, { message: "Required" })
+    .and(
+      z
+        .string()
+        .refine(
+          (value) => value.startsWith("evmos") || value.startsWith("0x"),
+          {
+            message: "Address must start with 'evmos' or '0x'",
+          }
+        )
+    ),
+  accountName: z.string(),
+  amount: z
+    .number({ invalid_type_error: "Required" })
+    .min(0)
+    .max(Number(dummyProps.available)),
+  planType: z.enum(plans),
+  vestingDuration: z.enum(duration),
+  vestingCliff: z.enum(cliff),
+  vestingSchedule: z.enum(schedule),
+  lockupDuration: z.enum(lockup),
+  startDate: z.coerce.date(),
+});

--- a/apps/vesting/src/components/vesting/header/helpers.ts
+++ b/apps/vesting/src/components/vesting/header/helpers.ts
@@ -4,6 +4,8 @@ export const getEndDate = (
   date: string | undefined,
   vestingDuration: string
 ) => {
+  console.log(date);
+  console.log(vestingDuration);
   const duration = Number(vestingDuration?.split(" ")[0]);
   const year = Number(date?.split("-")[0]);
   if (!isNaN(duration) && !isNaN(year)) {
@@ -88,3 +90,44 @@ export const schema = z.object({
   lockupDuration: z.enum(lockup),
   startDate: z.coerce.date(),
 });
+
+export const vestingSettingsConfig = {
+  [PlansType.Team]: {
+    duration: [Duration.FourYears],
+    cliff: [Duration.OneYear],
+    schedule: [Duration.Monthly],
+    lockup: [Duration.OneYear],
+    disabled: true,
+  },
+  [PlansType.Grantee]: {
+    duration: [Duration.OneYear],
+    cliff: [Duration.OneDay],
+    schedule: [Duration.Monthly],
+    lockup: [Duration.OneYear],
+    disabled: true,
+  },
+  [PlansType.Custom]: {
+    duration: [Duration.FourYears, Duration.OneYear],
+    cliff: [
+      Duration.None,
+      Duration.OneYear,
+      Duration.OneMonth,
+      Duration.OneDay,
+    ],
+    schedule: [Duration.Monthly, Duration.Quarterly],
+    lockup: [Duration.None, Duration.OneYear, Duration.OneMonth],
+    disabled: false,
+  },
+};
+
+export const DEFAULT_FORM_VALUES = {
+  address: "",
+  accountName: "",
+  amount: "",
+  planType: PlansType.Team,
+  vestingDuration: Duration.FourYears,
+  vestingCliff: Duration.OneYear,
+  vestingSchedule: Duration.Monthly,
+  lockupDuration: Duration.OneYear,
+  startDate: " ",
+};

--- a/apps/vesting/src/components/vesting/header/helpers.ts
+++ b/apps/vesting/src/components/vesting/header/helpers.ts
@@ -1,4 +1,3 @@
-// create test
 import * as z from "zod";
 export const getEndDate = (
   date: string | undefined,

--- a/package.json
+++ b/package.json
@@ -32,5 +32,10 @@
     "last 3 chrome version",
     "last 3 firefox version",
     "last 3 safari version"
-  ]
+  ],
+  "dependencies": {
+    "@hookform/resolvers": "^3.1.0",
+    "react-hook-form": "^7.44.3",
+    "zod": "^3.21.4"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -999,6 +999,11 @@
   dependencies:
     "@ethereumjs/util" "^8.0.0"
 
+"@hookform/resolvers@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@hookform/resolvers/-/resolvers-3.1.0.tgz#ff83ef4aa6078173201da131ceea4c3583b67034"
+  integrity sha512-z0A8K+Nxq+f83Whm/ajlwE6VtQlp/yPHZnXw7XWVPIGm1Vx0QV8KThU3BpbBRfAZ7/dYqCKKBNnQh85BkmBKkA==
+
 "@humanwhocodes/config-array@^0.11.8":
   version "0.11.8"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.8.tgz#03595ac2075a4dc0f191cc2131de14fbd7d410b9"
@@ -7998,6 +8003,11 @@ react-dom@18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
+react-hook-form@^7.44.3:
+  version "7.44.3"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.44.3.tgz#a99e560c6ef2b668db1daaebc4f98267331b6828"
+  integrity sha512-/tHId6p2ViAka1wECMw8FEPn/oz/w226zehHrJyQ1oIzCBNMIJCaj6ZkQcv+MjDxYh9MWR7RQic7Qqwe4a5nkw==
+
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -9726,6 +9736,11 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zod@^3.21.4:
+  version "3.21.4"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.21.4.tgz#10882231d992519f0a10b5dd58a38c9dabbb64db"
+  integrity sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==
 
 zustand@^4.3.1:
   version "4.3.6"


### PR DESCRIPTION
Create the modal for creating new vesting accounts
- Default option: Team
- Vesting duration, cliff, schedule and lockup are disabled if Team or Grantee are selected.
- When you select a date, it will show the end date (it adds the duration vesting value to the date selected) 
- The address has to start with evmos or 0x (Required)
- The account name is stored in the localstorage
- The amount has to be lower or equal than the available value. (Required)

![Screenshot 2023-06-12 at 18 00 51](https://github.com/evmos/apps/assets/40247040/6025e1ce-6105-4962-af02-077d7e5989b9)
