### PR TITLE
feat: use vesting endpoint for account detail - clawback modal

### DIFF
--- a/apps/vesting/src/components/vesting/Content.tsx
+++ b/apps/vesting/src/components/vesting/Content.tsx
@@ -6,28 +6,11 @@ import { Header } from "./header/Header";
 import { Navigation } from "ui-helpers";
 import { NAV_TO_VESTING } from "constants-helper";
 import { AccountDetails } from "./content/AccountDetails";
-import { getAccountDetails } from "./helpers";
 
 interface RouterQuery {
   account?: string;
 }
 
-// TODO: use it with the right information - use the useProposals as example
-const dummyAccountsProps = [
-  {
-    // eslint-disable-next-line no-secrets/no-secrets
-    accountAddress: "evmos1c8wgcmqde5jzymrjrflpp8j20ss000c00zd0ak",
-    // eslint-disable-next-line no-secrets/no-secrets
-    funderAddress: "evmos1cnr73vd4xcjm83xs8275twu06w3xqr6n7g5cud",
-    isVesting: true,
-  },
-  {
-    accountAddress: "0xaF3219826Cb708463B3AA3B73c6640A21497AE49",
-    // eslint-disable-next-line no-secrets/no-secrets
-    funderAddress: "testingFunder",
-    isVesting: true,
-  },
-];
 const Content = () => {
   const router = useRouter();
   const { account }: RouterQuery = router.query;
@@ -43,9 +26,7 @@ const Content = () => {
             A list of your vesting accounts will appear here in the next version
           </p>
         ) : (
-          <AccountDetails
-            props={getAccountDetails(dummyAccountsProps, account)[0]}
-          />
+          <AccountDetails account={account} />
         )}
       </div>
     </>

--- a/apps/vesting/src/components/vesting/Content.tsx
+++ b/apps/vesting/src/components/vesting/Content.tsx
@@ -20,13 +20,13 @@ const Content = () => {
 
   return (
     <>
-      {sanitizedAccount !== "undefined" && (
+      {sanitizedAccount !== undefined && (
         <Navigation href="/" text={NAV_TO_VESTING} />
       )}
       <Header />
 
       <div className="mt-8 w-full font-[IBM] text-pearl">
-        {sanitizedAccount === "undefined" ? (
+        {sanitizedAccount === undefined ? (
           <p className="flex justify-center ">
             A list of your vesting accounts will appear here in the next version
           </p>

--- a/apps/vesting/src/components/vesting/Content.tsx
+++ b/apps/vesting/src/components/vesting/Content.tsx
@@ -6,26 +6,11 @@ import { Header } from "./header/Header";
 import { Navigation } from "ui-helpers";
 import { NAV_TO_VESTING } from "constants-helper";
 import { AccountDetails } from "./content/AccountDetails";
+import { isValidAccount } from "./helpers";
 
 interface RouterQuery {
   account?: string;
 }
-
-const isValidAccount = (account?: string) => {
-  // console.log(account);
-
-  if (account === undefined) {
-    return "undefined";
-  }
-  const sanitizedAccount = account?.trim();
-  if (sanitizedAccount.startsWith("0x") && sanitizedAccount.length === 42) {
-    return sanitizedAccount;
-  }
-  if (sanitizedAccount.startsWith("evmos")) {
-    return sanitizedAccount;
-  }
-  return false;
-};
 
 const Content = () => {
   const router = useRouter();

--- a/apps/vesting/src/components/vesting/Content.tsx
+++ b/apps/vesting/src/components/vesting/Content.tsx
@@ -11,6 +11,20 @@ interface RouterQuery {
   account?: string;
 }
 
+const isValidAccount = (account?: string) => {
+  console.log(account);
+  if (account === undefined) {
+    return false;
+  }
+  if (account.startsWith("0x") && account.length === 42) {
+    return account;
+  }
+  if (account.startsWith("evmos")) {
+    return account;
+  }
+  return false;
+};
+
 const Content = () => {
   const router = useRouter();
   const { account }: RouterQuery = router.query;
@@ -26,7 +40,7 @@ const Content = () => {
             A list of your vesting accounts will appear here in the next version
           </p>
         ) : (
-          <AccountDetails account={account} />
+          <AccountDetails account={isValidAccount(account)} />
         )}
       </div>
     </>

--- a/apps/vesting/src/components/vesting/Content.tsx
+++ b/apps/vesting/src/components/vesting/Content.tsx
@@ -12,15 +12,17 @@ interface RouterQuery {
 }
 
 const isValidAccount = (account?: string) => {
-  console.log(account);
+  // console.log(account);
+
   if (account === undefined) {
-    return false;
+    return "undefined";
   }
-  if (account.startsWith("0x") && account.length === 42) {
-    return account;
+  const sanitizedAccount = account?.trim();
+  if (sanitizedAccount.startsWith("0x") && sanitizedAccount.length === 42) {
+    return sanitizedAccount;
   }
-  if (account.startsWith("evmos")) {
-    return account;
+  if (sanitizedAccount.startsWith("evmos")) {
+    return sanitizedAccount;
   }
   return false;
 };
@@ -29,18 +31,22 @@ const Content = () => {
   const router = useRouter();
   const { account }: RouterQuery = router.query;
 
+  const sanitizedAccount = isValidAccount(account);
+
   return (
     <>
-      {account !== undefined && <Navigation href="/" text={NAV_TO_VESTING} />}
+      {sanitizedAccount !== "undefined" && (
+        <Navigation href="/" text={NAV_TO_VESTING} />
+      )}
       <Header />
 
       <div className="mt-8 w-full font-[IBM] text-pearl">
-        {account === undefined ? (
+        {sanitizedAccount === "undefined" ? (
           <p className="flex justify-center ">
             A list of your vesting accounts will appear here in the next version
           </p>
         ) : (
-          <AccountDetails account={isValidAccount(account)} />
+          <AccountDetails account={sanitizedAccount} />
         )}
       </div>
     </>

--- a/apps/vesting/src/components/vesting/Content.tsx
+++ b/apps/vesting/src/components/vesting/Content.tsx
@@ -15,8 +15,6 @@ const Content = () => {
   const router = useRouter();
   const { account }: RouterQuery = router.query;
 
-  // const sanitizedAccount = isValidAccount(account);
-
   return (
     <>
       {account !== undefined && <Navigation href="/" text={NAV_TO_VESTING} />}

--- a/apps/vesting/src/components/vesting/Content.tsx
+++ b/apps/vesting/src/components/vesting/Content.tsx
@@ -6,7 +6,6 @@ import { Header } from "./header/Header";
 import { Navigation } from "ui-helpers";
 import { NAV_TO_VESTING } from "constants-helper";
 import { AccountDetails } from "./content/AccountDetails";
-import { isValidAccount } from "./helpers";
 
 interface RouterQuery {
   account?: string;
@@ -16,22 +15,20 @@ const Content = () => {
   const router = useRouter();
   const { account }: RouterQuery = router.query;
 
-  const sanitizedAccount = isValidAccount(account);
+  // const sanitizedAccount = isValidAccount(account);
 
   return (
     <>
-      {sanitizedAccount !== undefined && (
-        <Navigation href="/" text={NAV_TO_VESTING} />
-      )}
+      {account !== undefined && <Navigation href="/" text={NAV_TO_VESTING} />}
       <Header />
 
       <div className="mt-8 w-full font-[IBM] text-pearl">
-        {sanitizedAccount === undefined ? (
+        {account === undefined ? (
           <p className="flex justify-center ">
             A list of your vesting accounts will appear here in the next version
           </p>
         ) : (
-          <AccountDetails account={sanitizedAccount} />
+          <AccountDetails account={account} />
         )}
       </div>
     </>

--- a/apps/vesting/src/components/vesting/content/AccountDetails.tsx
+++ b/apps/vesting/src/components/vesting/content/AccountDetails.tsx
@@ -1,53 +1,81 @@
 import { useSelector } from "react-redux";
-import { ConfirmButton, Modal, ViewExplorer } from "ui-helpers";
+import { BannerMessages, ConfirmButton, Modal, ViewExplorer } from "ui-helpers";
 import { StoreType } from "evmos-wallet";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { ClawbackModal } from "./modal/ClawbackModal";
-import { VestingProps, getVestingAccountNameLocalstorage } from "../helpers";
+import { getVestingAccountNameLocalstorage } from "../helpers";
+import { useVestingAccounts } from "../../../internal/hooks/useVesting";
 
-export const AccountDetails = ({ props }: { props: VestingProps }) => {
+export const AccountDetails = ({
+  account,
+}: {
+  account: string | undefined;
+}) => {
   const [showModal, setShowModal] = useState(false);
   const [modalContent, setModalContent] = useState<JSX.Element>(<></>);
-  const handleClawbackClick = () => {
-    setShowModal(true);
-    setModalContent(<ClawbackModal />);
-  };
+
   const accountName = getVestingAccountNameLocalstorage();
   const value = useSelector((state: StoreType) => state.wallet.value);
-  return !props?.isVesting ? (
-    <div className="flex items-center justify-center rounded-2xl bg-darkGray2 p-5">
-      There is no vesting account linked to this address
-    </div>
-  ) : (
-    <section className="break-words">
-      <h1 className="text-2xl">Vesting Account Details</h1>
-      <div className="my-5 mr-1 space-y-5 rounded-2xl bg-darkGray2 p-5 font-[IBM] text-sm text-pearl xl:mx-0 ">
-        <div className="flex items-center justify-between">
-          <h2 className="text-lg uppercase">{accountName} Account</h2>
-          <ConfirmButton
-            text="Clawback"
-            onClick={handleClawbackClick}
-            className="w-fit"
-            disabled={!value.active}
-          />
+
+  const { loading, error, vestingDetails } = useVestingAccounts(account);
+
+  const handleClawbackClick = useCallback(() => {
+    setShowModal(true);
+    if (typeof vestingDetails !== "string") {
+      setModalContent(<ClawbackModal vestingDetails={vestingDetails} />);
+    }
+  }, [vestingDetails]);
+  const drawContentVesting = useCallback(() => {
+    if (loading) {
+      return <BannerMessages text="Loading..." spinner={true} />;
+    }
+    if (error) {
+      return <BannerMessages text="No results" />;
+    }
+    if (typeof vestingDetails === "string") {
+      return <BannerMessages text={vestingDetails} />;
+    }
+
+    return (
+      <section className="break-words">
+        <h1 className="text-2xl">Vesting Account Details</h1>
+        <div className="my-5 mr-1 space-y-5 rounded-2xl bg-darkGray2 p-5 font-[IBM] text-sm text-pearl xl:mx-0 ">
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg uppercase">{accountName} Account</h2>
+            <ConfirmButton
+              text="Clawback"
+              onClick={handleClawbackClick}
+              className="w-fit"
+              disabled={
+                !value.active ||
+                value.evmosAddressCosmosFormat !== vestingDetails.funderAddress
+              }
+            />
+          </div>
+          <div>
+            <h3 className="opacity-60">Account Address</h3>
+            <ViewExplorer
+              txHash={vestingDetails.accountAddress}
+              explorerTxUrl="https://www.mintscan.io/evmos/account"
+              text={vestingDetails.accountAddress}
+            />
+          </div>
+          <div>
+            <h3 className="opacity-60">Funder Address</h3>
+            <ViewExplorer
+              txHash={vestingDetails.funderAddress}
+              explorerTxUrl="https://www.mintscan.io/evmos/account"
+              text={vestingDetails.funderAddress}
+            />
+          </div>
         </div>
-        <div>
-          <h3 className="opacity-60">Account Address</h3>
-          <ViewExplorer
-            txHash={props.accountAddress}
-            explorerTxUrl="https://www.mintscan.io/evmos/account"
-            text={props.accountAddress}
-          />
-        </div>
-        <div>
-          <h3 className="opacity-60">Funder Address</h3>
-          <ViewExplorer
-            txHash={props.funderAddress}
-            explorerTxUrl="https://www.mintscan.io/evmos/account"
-            text={props.funderAddress}
-          />
-        </div>
-      </div>
+      </section>
+    );
+  }, [error, loading, vestingDetails, accountName, handleClawbackClick, value]);
+
+  return (
+    <>
+      {drawContentVesting()}
       <Modal
         show={showModal}
         onClose={() => {
@@ -56,6 +84,6 @@ export const AccountDetails = ({ props }: { props: VestingProps }) => {
       >
         {modalContent}
       </Modal>
-    </section>
+    </>
   );
 };

--- a/apps/vesting/src/components/vesting/content/AccountDetails.tsx
+++ b/apps/vesting/src/components/vesting/content/AccountDetails.tsx
@@ -6,11 +6,7 @@ import { ClawbackModal } from "./modal/ClawbackModal";
 import { getVestingAccountNameLocalstorage } from "../helpers";
 import { useVestingAccounts } from "../../../internal/hooks/useVesting";
 
-export const AccountDetails = ({
-  account,
-}: {
-  account: string | undefined;
-}) => {
+export const AccountDetails = ({ account }: { account: string | false }) => {
   const [showModal, setShowModal] = useState(false);
   const [modalContent, setModalContent] = useState<JSX.Element>(<></>);
 

--- a/apps/vesting/src/components/vesting/content/AccountDetails.tsx
+++ b/apps/vesting/src/components/vesting/content/AccountDetails.tsx
@@ -6,7 +6,7 @@ import { ClawbackModal } from "./modal/ClawbackModal";
 import { getVestingAccountNameLocalstorage } from "../helpers";
 import { useVestingAccounts } from "../../../internal/hooks/useVesting";
 
-export const AccountDetails = ({ account }: { account?: string | false }) => {
+export const AccountDetails = ({ account }: { account?: string }) => {
   const [showModal, setShowModal] = useState(false);
   const [modalContent, setModalContent] = useState<JSX.Element>(<></>);
 

--- a/apps/vesting/src/components/vesting/content/AccountDetails.tsx
+++ b/apps/vesting/src/components/vesting/content/AccountDetails.tsx
@@ -6,7 +6,7 @@ import { ClawbackModal } from "./modal/ClawbackModal";
 import { getVestingAccountNameLocalstorage } from "../helpers";
 import { useVestingAccounts } from "../../../internal/hooks/useVesting";
 
-export const AccountDetails = ({ account }: { account: string | false }) => {
+export const AccountDetails = ({ account }: { account?: string | false }) => {
   const [showModal, setShowModal] = useState(false);
   const [modalContent, setModalContent] = useState<JSX.Element>(<></>);
 

--- a/apps/vesting/src/components/vesting/content/modal/ClawbackModal.tsx
+++ b/apps/vesting/src/components/vesting/content/modal/ClawbackModal.tsx
@@ -1,32 +1,46 @@
 import { ConfirmButton, ModalTitle } from "ui-helpers";
 import { ItemModal } from "./ItemModal";
 import { ExclamationIcon } from "icons";
-const dummyProps = {
-  // eslint-disable-next-line no-secrets/no-secrets
-  address: "evmosc5ljcjw341ls6f7xpfvakm2amg962y84z3kell8ks",
-  totalTokens: "1,000,000",
-  availableClawback: "944,444",
-};
+import { VestingAccountDetail } from "../../../../internal/types";
+import { convertFromAtto, formatNumber } from "helpers";
+
 // TODO: format totalTokens and availableClawback depending on the response
-export const ClawbackModal = () => {
+export const ClawbackModal = ({
+  vestingDetails,
+}: {
+  vestingDetails: VestingAccountDetail;
+}) => {
   const handleOnClick = () => {
     // TODO: logic for clawback
   };
 
+  const totalTokens = () => {
+    return formatNumber(convertFromAtto(vestingDetails.unvestedAmount, 18), 6);
+  };
+
+  const availableClawback = () => {
+    return formatNumber(
+      convertFromAtto(vestingDetails.originalVestingAmount, 18),
+      6
+    );
+  };
   return (
     <div className="space-y-5">
       <ModalTitle title="Clawback Tokens" />
       <div className=" rounded border-2 border-darkGray2 p-4">
         Clawback retrieves all unvested tokens from a vesting account.
       </div>
-      <ItemModal title="Account Address" description={dummyProps.address} />
+      <ItemModal
+        title="Account Address"
+        description={vestingDetails.accountAddress}
+      />
       <ItemModal
         title="Total Vesting Tokens"
-        description={`${dummyProps.totalTokens} EVMOS `}
+        description={`${totalTokens()} EVMOS `}
       />
       <ItemModal
         title="Available for Clawback"
-        description={`${dummyProps.availableClawback} EVMOS `}
+        description={`${availableClawback()} EVMOS `}
       />
       <div>
         <div className="flex items-center space-x-1 ">

--- a/apps/vesting/src/components/vesting/helpers.spec.tsx
+++ b/apps/vesting/src/components/vesting/helpers.spec.tsx
@@ -1,4 +1,4 @@
-import { Duration, getEndDate, getEvmosAddress } from "./helpers";
+import { Duration, getEndDate } from "./helpers";
 
 describe("Vesting UI helpers", () => {
   it("should return true and the end date formatted", () => {
@@ -13,33 +13,5 @@ describe("Vesting UI helpers", () => {
     const vestingDuration = Duration.FourYears;
     const msg = getEndDate(date, vestingDuration);
     expect(msg).toStrictEqual([false, ""]);
-  });
-
-  it("should return the formatted evmos address", () => {
-    // eslint-disable-next-line no-secrets/no-secrets
-    const address = getEvmosAddress(
-      "0xaF3219826Cb708463B3AA3B73c6640A21497AE49"
-    );
-    // eslint-disable-next-line no-secrets/no-secrets
-    expect(address).toBe("evmos14uepnqnvkuyyvwe65wmncejq5g2f0tjft3wr65");
-  });
-
-  it("should return the same hex address", () => {
-    const address = getEvmosAddress("0xaF3219826Cb70846");
-    expect(address).toBe("0xaF3219826Cb70846");
-  });
-
-  it("should return the same evmos address", () => {
-    const address = getEvmosAddress(
-      // eslint-disable-next-line no-secrets/no-secrets
-      "evmos14uepnqnvkuyyvwe65wmncejq5g2f0tjft3wr65"
-    );
-    // eslint-disable-next-line no-secrets/no-secrets
-    expect(address).toBe("evmos14uepnqnvkuyyvwe65wmncejq5g2f0tjft3wr65");
-  });
-
-  it("should return the same empty address", () => {
-    const address = getEvmosAddress("");
-    expect(address).toBe("");
   });
 });

--- a/apps/vesting/src/components/vesting/helpers.spec.tsx
+++ b/apps/vesting/src/components/vesting/helpers.spec.tsx
@@ -1,4 +1,9 @@
-import { Duration, getEndDate, isValidAccount } from "./helpers";
+import {
+  Duration,
+  getEndDate,
+  isEthereumAddressValid,
+  isEvmosAddressValid,
+} from "./helpers";
 
 describe("Vesting UI helpers", () => {
   it("should return true and the end date formatted", () => {
@@ -15,35 +20,29 @@ describe("Vesting UI helpers", () => {
     expect(msg).toStrictEqual([false, ""]);
   });
 
-  it("should return false - Account undefined", () => {
-    const account = undefined;
-    const address = isValidAccount(account);
-    expect(address).toBe(false);
-  });
-
   it("should return false - Evmos account with incorrect format", () => {
     const account = "evmos1c8wg";
-    const address = isValidAccount(account);
+    const address = isEvmosAddressValid(account);
     expect(address).toBe(false);
   });
 
   it("should return false - Hex account with incorrect format", () => {
     const account = "0x123";
-    const address = isValidAccount(account);
+    const address = isEthereumAddressValid(account);
     expect(address).toBe(false);
   });
 
   it("should return true - Hex account with correct format", () => {
     // eslint-disable-next-line no-secrets/no-secrets
     const account = "0x4b87B15f560a9b77BB9965c49862cfCe720c52Ab";
-    const address = isValidAccount(account);
-    expect(address).toBe(account);
+    const address = isEthereumAddressValid(account);
+    expect(address).toBe(true);
   });
 
   it("should return true - Evmos account with correct format", () => {
     // eslint-disable-next-line no-secrets/no-secrets
     const account = "evmos1fwrmzh6kp2dh0wuevhzfsck0eeeqc54tpvkvc2";
-    const address = isValidAccount(account);
-    expect(address).toBe(account);
+    const address = isEvmosAddressValid(account);
+    expect(address).toBe(true);
   });
 });

--- a/apps/vesting/src/components/vesting/helpers.spec.tsx
+++ b/apps/vesting/src/components/vesting/helpers.spec.tsx
@@ -1,4 +1,4 @@
-import { Duration, getEndDate } from "./helpers";
+import { Duration, getEndDate, isValidAccount } from "./helpers";
 
 describe("Vesting UI helpers", () => {
   it("should return true and the end date formatted", () => {
@@ -13,5 +13,37 @@ describe("Vesting UI helpers", () => {
     const vestingDuration = Duration.FourYears;
     const msg = getEndDate(date, vestingDuration);
     expect(msg).toStrictEqual([false, ""]);
+  });
+
+  it("should return false - Account undefined", () => {
+    const account = undefined;
+    const address = isValidAccount(account);
+    expect(address).toBe(false);
+  });
+
+  it("should return false - Evmos account with incorrect format", () => {
+    const account = "evmos1c8wg";
+    const address = isValidAccount(account);
+    expect(address).toBe(false);
+  });
+
+  it("should return false - Hex account with incorrect format", () => {
+    const account = "0x123";
+    const address = isValidAccount(account);
+    expect(address).toBe(false);
+  });
+
+  it("should return true - Hex account with correct format", () => {
+    // eslint-disable-next-line no-secrets/no-secrets
+    const account = "0x4b87B15f560a9b77BB9965c49862cfCe720c52Ab";
+    const address = isValidAccount(account);
+    expect(address).toBe(account);
+  });
+
+  it("should return true - Evmos account with correct format", () => {
+    // eslint-disable-next-line no-secrets/no-secrets
+    const account = "evmos1fwrmzh6kp2dh0wuevhzfsck0eeeqc54tpvkvc2";
+    const address = isValidAccount(account);
+    expect(address).toBe(account);
   });
 });

--- a/apps/vesting/src/components/vesting/helpers.ts
+++ b/apps/vesting/src/components/vesting/helpers.ts
@@ -144,7 +144,8 @@ export const isValidAccount = (account?: string) => {
   // console.log(account);
 
   if (account === undefined) {
-    return "undefined";
+    // TODO: modify this
+    return undefined;
   }
   const sanitizedAccount = account?.trim();
   if (sanitizedAccount.startsWith("0x") && sanitizedAccount.length === 42) {

--- a/apps/vesting/src/components/vesting/helpers.ts
+++ b/apps/vesting/src/components/vesting/helpers.ts
@@ -150,7 +150,7 @@ export const isValidAccount = (account?: string) => {
   if (sanitizedAccount.startsWith("0x") && sanitizedAccount.length === 42) {
     return sanitizedAccount;
   }
-  if (sanitizedAccount.startsWith("evmos")) {
+  if (sanitizedAccount.startsWith("evmos") && sanitizedAccount.length === 44) {
     return sanitizedAccount;
   }
   return false;

--- a/apps/vesting/src/components/vesting/helpers.ts
+++ b/apps/vesting/src/components/vesting/helpers.ts
@@ -139,3 +139,19 @@ export interface VestingProps {
   funderAddress: string;
   isVesting: boolean;
 }
+
+export const isValidAccount = (account?: string) => {
+  // console.log(account);
+
+  if (account === undefined) {
+    return "undefined";
+  }
+  const sanitizedAccount = account?.trim();
+  if (sanitizedAccount.startsWith("0x") && sanitizedAccount.length === 42) {
+    return sanitizedAccount;
+  }
+  if (sanitizedAccount.startsWith("evmos")) {
+    return sanitizedAccount;
+  }
+  return false;
+};

--- a/apps/vesting/src/components/vesting/helpers.ts
+++ b/apps/vesting/src/components/vesting/helpers.ts
@@ -1,5 +1,4 @@
 import * as z from "zod";
-import { ethToEvmos } from "@evmos/address-converter";
 
 export const getEndDate = (
   date: string | undefined,
@@ -140,38 +139,3 @@ export interface VestingProps {
   funderAddress: string;
   isVesting: boolean;
 }
-
-export const getEvmosAddress = (account: string | undefined) => {
-  if (account !== undefined) {
-    if (account.startsWith("0x")) {
-      // && account.length == 42
-      try {
-        return ethToEvmos(account);
-      } catch (e) {
-        return account;
-      }
-    }
-  }
-  return account;
-};
-
-// TODO: this function will change when we use the correct information
-// TODO: see if it is necessary the test for this.
-export const getAccountDetails = (
-  dummyAccountsProps: VestingProps[],
-  account: string | undefined
-) => {
-  const address = getEvmosAddress(account);
-
-  const filteredProps = dummyAccountsProps.filter((e) => {
-    if (e.accountAddress.startsWith("0x")) {
-      return ethToEvmos(e.accountAddress) === address;
-    }
-    if (e.accountAddress.startsWith("evmos")) {
-      return e.accountAddress === address;
-    }
-    return false;
-  });
-
-  return filteredProps;
-};

--- a/apps/vesting/src/components/vesting/helpers.ts
+++ b/apps/vesting/src/components/vesting/helpers.ts
@@ -161,7 +161,9 @@ export const isValidAccount = (account?: string) => {
   if (acc === undefined) {
     return false;
   }
-
+  if (typeof acc !== "string") {
+    return false;
+  }
   if (isEthereumAddressValid(acc)) {
     address = acc;
   }

--- a/apps/vesting/src/components/vesting/helpers.ts
+++ b/apps/vesting/src/components/vesting/helpers.ts
@@ -167,7 +167,7 @@ export const isValidAccount = (account?: string) => {
   if (isEthereumAddressValid(acc)) {
     address = acc;
   }
-  if (isEvmosAddressValid(acc)) {
+  if (acc.startsWith("evmos") && isEvmosAddressValid(acc)) {
     address = acc;
   }
   if (address === "") {

--- a/apps/vesting/src/components/vesting/helpers.ts
+++ b/apps/vesting/src/components/vesting/helpers.ts
@@ -141,11 +141,14 @@ export interface VestingProps {
 }
 
 export const isEthereumAddressValid = (address: string): boolean => {
-  const ethereumAddressRegex = /^(0x)?[0-9a-fA-F]{40}$/;
+  const ethereumAddressRegex = /^0x[0-9a-fA-F]{42}$/;
   return ethereumAddressRegex.test(address);
 };
 
 export const isEvmosAddressValid = (address: string): boolean => {
+  if (!address.startsWith("evmos")) {
+    return false;
+  }
   try {
     const ethAddress = evmosToEth(address);
     return isEthereumAddressValid(ethAddress);

--- a/apps/vesting/src/components/vesting/helpers.ts
+++ b/apps/vesting/src/components/vesting/helpers.ts
@@ -1,5 +1,5 @@
 import * as z from "zod";
-
+import { evmosToEth } from "@evmos/address-converter";
 export const getEndDate = (
   date: string | undefined,
   vestingDuration: string
@@ -140,19 +140,36 @@ export interface VestingProps {
   isVesting: boolean;
 }
 
-export const isValidAccount = (account?: string) => {
-  // console.log(account);
+const isEthereumAddressValid = (address: string): boolean => {
+  const ethereumAddressRegex = /^(0x)?[0-9a-fA-F]{40}$/;
+  return ethereumAddressRegex.test(address);
+};
 
-  if (account === undefined) {
-    // TODO: modify this
-    return undefined;
+const isEvmosAddressValid = (address: string): boolean => {
+  try {
+    const ethAddress = evmosToEth(address);
+    return isEthereumAddressValid(ethAddress);
+  } catch (error) {
+    return false;
   }
-  const sanitizedAccount = account?.trim();
-  if (sanitizedAccount.startsWith("0x") && sanitizedAccount.length === 42) {
-    return sanitizedAccount;
+};
+
+export const isValidAccount = (account?: string) => {
+  const acc = account?.trim();
+  let address: string = "";
+
+  if (acc === undefined) {
+    return false;
   }
-  if (sanitizedAccount.startsWith("evmos") && sanitizedAccount.length === 44) {
-    return sanitizedAccount;
+
+  if (isEthereumAddressValid(acc)) {
+    address = acc;
   }
-  return false;
+  if (isEvmosAddressValid(acc)) {
+    address = acc;
+  }
+  if (address === "") {
+    return false;
+  }
+  return address;
 };

--- a/apps/vesting/src/components/vesting/helpers.ts
+++ b/apps/vesting/src/components/vesting/helpers.ts
@@ -1,5 +1,5 @@
 import * as z from "zod";
-import { evmosToEth } from "@evmos/address-converter";
+
 export const getEndDate = (
   date: string | undefined,
   vestingDuration: string
@@ -141,40 +141,12 @@ export interface VestingProps {
 }
 
 export const isEthereumAddressValid = (address: string): boolean => {
-  const ethereumAddressRegex = /^0x[0-9a-fA-F]{42}$/;
+  const ethereumAddressRegex = /^0x[0-9a-fA-F]{40}$/;
   return ethereumAddressRegex.test(address);
 };
 
 export const isEvmosAddressValid = (address: string): boolean => {
-  if (!address.startsWith("evmos")) {
-    return false;
-  }
-  try {
-    const ethAddress = evmosToEth(address);
-    return isEthereumAddressValid(ethAddress);
-  } catch (error) {
-    return false;
-  }
-};
-
-export const isValidAccount = (account?: string) => {
-  const acc = account?.trim();
-  let address: string = "";
-
-  if (acc === undefined) {
-    return false;
-  }
-  if (typeof acc !== "string") {
-    return false;
-  }
-  if (isEthereumAddressValid(acc)) {
-    address = acc;
-  }
-  if (acc.startsWith("evmos") && isEvmosAddressValid(acc)) {
-    address = acc;
-  }
-  if (address === "") {
-    return false;
-  }
-  return address;
+  // TODO: are evmos wallet always 44 characters ?
+  const evmosAddressRegex = /^evmos[0-9a-zA-Z]{39}$/;
+  return evmosAddressRegex.test(address);
 };

--- a/apps/vesting/src/components/vesting/helpers.ts
+++ b/apps/vesting/src/components/vesting/helpers.ts
@@ -140,12 +140,12 @@ export interface VestingProps {
   isVesting: boolean;
 }
 
-const isEthereumAddressValid = (address: string): boolean => {
+export const isEthereumAddressValid = (address: string): boolean => {
   const ethereumAddressRegex = /^(0x)?[0-9a-fA-F]{40}$/;
   return ethereumAddressRegex.test(address);
 };
 
-const isEvmosAddressValid = (address: string): boolean => {
+export const isEvmosAddressValid = (address: string): boolean => {
   try {
     const ethAddress = evmosToEth(address);
     return isEthereumAddressValid(ethAddress);

--- a/apps/vesting/src/internal/fetch.ts
+++ b/apps/vesting/src/internal/fetch.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
 
 // import { EVMOS_BACKEND } from "evmos-wallet";
+import { isValidAccount } from "../components/vesting/helpers";
 import { VestingResponse } from "./types";
 
 // TODO: change EVMOS_STAGING_BACKEND to EVMOS_BACKEND
@@ -10,6 +11,11 @@ const EVMOS_STAGING_BACKEND = "https://goapi-staging.evmos.org";
 export const getVesting = async (account: string | false) => {
   if (account === false || account === "undefined") {
     return "There is no vesting account linked to this address.";
+  }
+
+  const isValid = isValidAccount(account);
+  if (!isValid || isValid === "undefined") {
+    return "Invalid account parameter.";
   }
   try {
     const res = await fetch(`${EVMOS_STAGING_BACKEND}/v2/vesting/${account}`);

--- a/apps/vesting/src/internal/fetch.ts
+++ b/apps/vesting/src/internal/fetch.ts
@@ -9,12 +9,12 @@ import { VestingResponse } from "./types";
 const EVMOS_STAGING_BACKEND = "https://goapi-staging.evmos.org";
 
 export const getVesting = async (account: string | false) => {
-  if (account === false || typeof account === "undefined") {
+  if (account === false || account === "undefined") {
     return "There is no vesting account linked to this address.";
   }
 
   const isValid = isValidAccount(account);
-  if (!isValid || typeof isValid === "undefined") {
+  if (!isValid || isValid === "undefined") {
     return "Invalid account parameter.";
   }
   try {

--- a/apps/vesting/src/internal/fetch.ts
+++ b/apps/vesting/src/internal/fetch.ts
@@ -14,9 +14,8 @@ const isValidAccount = (account: string) => {
   }
   if (account.startsWith("evmos")) {
     return true;
-  } else {
-    return false;
   }
+  return false;
 };
 
 export const getVesting = async (account?: string) => {

--- a/apps/vesting/src/internal/fetch.ts
+++ b/apps/vesting/src/internal/fetch.ts
@@ -1,0 +1,21 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
+
+// import { EVMOS_BACKEND } from "evmos-wallet";
+import { VestingResponse } from "./types";
+import { DEFAULT_VESTING_VALUES } from "./helpers";
+
+// TODO: change EVMOS_STAGING_BACKEND to EVMOS_BACKEND
+const EVMOS_STAGING_BACKEND = "https://goapi-staging.evmos.org";
+
+export const getVesting = async (account?: string) => {
+  if (account === undefined) {
+    return DEFAULT_VESTING_VALUES;
+  }
+  try {
+    const res = await fetch(`${EVMOS_STAGING_BACKEND}/v2/vesting/${account}`);
+    return res.json() as Promise<VestingResponse>;
+  } catch (error) {
+    return "Error while getting vesting account info";
+  }
+};

--- a/apps/vesting/src/internal/fetch.ts
+++ b/apps/vesting/src/internal/fetch.ts
@@ -2,23 +2,35 @@
 // SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
 
 // import { EVMOS_BACKEND } from "evmos-wallet";
-import { isValidAccount } from "../components/vesting/helpers";
 import { VestingResponse } from "./types";
 
 // TODO: change EVMOS_STAGING_BACKEND to EVMOS_BACKEND
 const EVMOS_STAGING_BACKEND = "https://goapi-staging.evmos.org";
 
-export const getVesting = async (account?: string | false) => {
-  if (account === false || account === undefined) {
+export const getVesting = async (account?: string) => {
+  const acc = account?.trim();
+  let address: string = "";
+  if (acc === undefined) {
+    return "There is no vesting account linked to this address.";
+  }
+  if (acc === null) {
+    return "There is no vesting account linked to this address.";
+  }
+  if (typeof acc !== "string") {
+    return "There is no vesting account linked to this address.";
+  }
+  if (acc.startsWith("0x") && acc.length === 42) {
+    address = acc;
+  }
+  if (acc.startsWith("evmos") && acc.length === 44) {
+    address = acc;
+  }
+  if (address === "") {
     return "There is no vesting account linked to this address.";
   }
 
-  const isValid = isValidAccount(account);
-  if (!isValid || isValid === undefined || typeof isValid !== "string") {
-    return "There is no vesting account linked to this address.";
-  }
   try {
-    const res = await fetch(`${EVMOS_STAGING_BACKEND}/v2/vesting/${isValid}`);
+    const res = await fetch(`${EVMOS_STAGING_BACKEND}/v2/vesting/${address}`);
     return res.json() as Promise<VestingResponse>;
   } catch (error) {
     return "Error while getting vesting account info";

--- a/apps/vesting/src/internal/fetch.ts
+++ b/apps/vesting/src/internal/fetch.ts
@@ -9,12 +9,12 @@ import { VestingResponse } from "./types";
 const EVMOS_STAGING_BACKEND = "https://goapi-staging.evmos.org";
 
 export const getVesting = async (account: string | false) => {
-  if (account === false || account === "undefined") {
+  if (account === false || typeof account === "undefined") {
     return "There is no vesting account linked to this address.";
   }
 
   const isValid = isValidAccount(account);
-  if (!isValid || isValid === "undefined") {
+  if (!isValid || typeof isValid === "undefined") {
     return "Invalid account parameter.";
   }
   try {

--- a/apps/vesting/src/internal/fetch.ts
+++ b/apps/vesting/src/internal/fetch.ts
@@ -6,7 +6,7 @@ import { isValidAccount } from "../components/vesting/helpers";
 import { VestingResponse } from "./types";
 
 // TODO: change EVMOS_STAGING_BACKEND to EVMOS_BACKEND
-// const EVMOS_STAGING_BACKEND = "https://goapi-staging.evmos.org";
+const EVMOS_STAGING_BACKEND = "https://goapi-staging.evmos.org";
 
 export const getVesting = async (account: string | false) => {
   if (account === false || account === "undefined") {
@@ -20,7 +20,7 @@ export const getVesting = async (account: string | false) => {
   try {
     const res = await fetch(
       // eslint-disable-next-line no-secrets/no-secrets
-      `https://goapi-staging.evmos.org/v2/vesting/evmos1fwrmzh6kp2dh0wuevhzfsck0eeeqc54tpvkvc2`
+      `${EVMOS_STAGING_BACKEND}/v2/vesting/evmos1fwrmzh6kp2dh0wuevhzfsck0eeeqc54tpvkvc2`
     );
     return res.json() as Promise<VestingResponse>;
   } catch (error) {

--- a/apps/vesting/src/internal/fetch.ts
+++ b/apps/vesting/src/internal/fetch.ts
@@ -18,7 +18,7 @@ export const getVesting = async (account: string | false) => {
     return "Invalid account parameter.";
   }
   try {
-    const res = await fetch(`${EVMOS_STAGING_BACKEND}/v2/vesting/${account}`);
+    const res = await fetch(`${EVMOS_STAGING_BACKEND}/v2/vesting/${isValid}`);
     return res.json() as Promise<VestingResponse>;
   } catch (error) {
     return "Error while getting vesting account info";

--- a/apps/vesting/src/internal/fetch.ts
+++ b/apps/vesting/src/internal/fetch.ts
@@ -8,8 +8,19 @@ import { DEFAULT_VESTING_VALUES } from "./helpers";
 // TODO: change EVMOS_STAGING_BACKEND to EVMOS_BACKEND
 const EVMOS_STAGING_BACKEND = "https://goapi-staging.evmos.org";
 
+const isValidAccount = (account: string) => {
+  if (account.startsWith("0x") && account.length === 42) {
+    return true;
+  }
+  if (account.startsWith("evmos")) {
+    return true;
+  } else {
+    return false;
+  }
+};
+
 export const getVesting = async (account?: string) => {
-  if (account === undefined) {
+  if (account === undefined || !isValidAccount(account)) {
     return DEFAULT_VESTING_VALUES;
   }
   try {

--- a/apps/vesting/src/internal/fetch.ts
+++ b/apps/vesting/src/internal/fetch.ts
@@ -8,7 +8,7 @@ import { VestingResponse } from "./types";
 const EVMOS_STAGING_BACKEND = "https://goapi-staging.evmos.org";
 
 export const getVesting = async (account: string | false) => {
-  if (account === false) {
+  if (account === false || account === "undefined") {
     return "There is no vesting account linked to this address.";
   }
   try {

--- a/apps/vesting/src/internal/fetch.ts
+++ b/apps/vesting/src/internal/fetch.ts
@@ -3,21 +3,14 @@
 
 // import { EVMOS_BACKEND } from "evmos-wallet";
 
+import {
+  isEthereumAddressValid,
+  isEvmosAddressValid,
+} from "../components/vesting/helpers";
 import { VestingResponse } from "./types";
 
 // TODO: change EVMOS_STAGING_BACKEND to EVMOS_BACKEND
 const EVMOS_STAGING_BACKEND = "https://goapi-staging.evmos.org";
-
-const isEthereumAddressValid = (address: string): boolean => {
-  const ethereumAddressRegex = /^0x[0-9a-fA-F]{40}$/;
-  return ethereumAddressRegex.test(address);
-};
-
-const isEvmosAddressValid = (address: string): boolean => {
-  // TODO: this one is not working correctly
-  const evmosAddressRegex = /^evmos[0-9a-zA-Z]{42}$/;
-  return evmosAddressRegex.test(address);
-};
 
 export const getVesting = async (account?: string) => {
   const acc = account?.trim();

--- a/apps/vesting/src/internal/fetch.ts
+++ b/apps/vesting/src/internal/fetch.ts
@@ -6,7 +6,7 @@ import { isValidAccount } from "../components/vesting/helpers";
 import { VestingResponse } from "./types";
 
 // TODO: change EVMOS_STAGING_BACKEND to EVMOS_BACKEND
-const EVMOS_STAGING_BACKEND = "https://goapi-staging.evmos.org";
+// const EVMOS_STAGING_BACKEND = "https://goapi-staging.evmos.org";
 
 export const getVesting = async (account: string | false) => {
   if (account === false || account === "undefined") {
@@ -18,7 +18,10 @@ export const getVesting = async (account: string | false) => {
     return "Invalid account parameter.";
   }
   try {
-    const res = await fetch(`${EVMOS_STAGING_BACKEND}/v2/vesting/${isValid}`);
+    const res = await fetch(
+      // eslint-disable-next-line no-secrets/no-secrets
+      `https://goapi-staging.evmos.org/v2/vesting/evmos1fwrmzh6kp2dh0wuevhzfsck0eeeqc54tpvkvc2`
+    );
     return res.json() as Promise<VestingResponse>;
   } catch (error) {
     return "Error while getting vesting account info";

--- a/apps/vesting/src/internal/fetch.ts
+++ b/apps/vesting/src/internal/fetch.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
 
 // import { EVMOS_BACKEND } from "evmos-wallet";
-import { isValidAccount } from "../components/vesting/helpers";
+// import { isValidAccount } from "../components/vesting/helpers";
 import { VestingResponse } from "./types";
 
 // TODO: change EVMOS_STAGING_BACKEND to EVMOS_BACKEND
@@ -13,15 +13,12 @@ export const getVesting = async (account: string | false) => {
     return "There is no vesting account linked to this address.";
   }
 
-  const isValid = isValidAccount(account);
-  if (!isValid || isValid === "undefined") {
-    return "Invalid account parameter.";
-  }
+  // const isValid = isValidAccount(account);
+  // if (!isValid || isValid === "undefined") {
+  //   return "There is no vesting account linked to this address.";
+  // }
   try {
-    const res = await fetch(
-      // eslint-disable-next-line no-secrets/no-secrets
-      `${EVMOS_STAGING_BACKEND}/v2/vesting/evmos1fwrmzh6kp2dh0wuevhzfsck0eeeqc54tpvkvc2`
-    );
+    const res = await fetch(`${EVMOS_STAGING_BACKEND}/v2/vesting/${account}`);
     return res.json() as Promise<VestingResponse>;
   } catch (error) {
     return "Error while getting vesting account info";

--- a/apps/vesting/src/internal/fetch.ts
+++ b/apps/vesting/src/internal/fetch.ts
@@ -3,24 +3,13 @@
 
 // import { EVMOS_BACKEND } from "evmos-wallet";
 import { VestingResponse } from "./types";
-import { DEFAULT_VESTING_VALUES } from "./helpers";
 
 // TODO: change EVMOS_STAGING_BACKEND to EVMOS_BACKEND
 const EVMOS_STAGING_BACKEND = "https://goapi-staging.evmos.org";
 
-const isValidAccount = (account: string) => {
-  if (account.startsWith("0x") && account.length === 42) {
-    return true;
-  }
-  if (account.startsWith("evmos")) {
-    return true;
-  }
-  return false;
-};
-
-export const getVesting = async (account?: string) => {
-  if (account === undefined || !isValidAccount(account)) {
-    return DEFAULT_VESTING_VALUES;
+export const getVesting = async (account: string | false) => {
+  if (account === false) {
+    return "There is no vesting account linked to this address.";
   }
   try {
     const res = await fetch(`${EVMOS_STAGING_BACKEND}/v2/vesting/${account}`);

--- a/apps/vesting/src/internal/fetch.ts
+++ b/apps/vesting/src/internal/fetch.ts
@@ -3,16 +3,32 @@
 
 // import { EVMOS_BACKEND } from "evmos-wallet";
 
-import { isValidAccount } from "../components/vesting/helpers";
+import {
+  isEthereumAddressValid,
+  isEvmosAddressValid,
+} from "../components/vesting/helpers";
 import { VestingResponse } from "./types";
 
 // TODO: change EVMOS_STAGING_BACKEND to EVMOS_BACKEND
 const EVMOS_STAGING_BACKEND = "https://goapi-staging.evmos.org";
 
 export const getVesting = async (account?: string) => {
-  const address = isValidAccount(account);
+  const acc = account?.trim();
+  let address: string = "";
 
-  if (typeof address === "boolean" && address === false) {
+  if (acc === undefined) {
+    return "There is no vesting account linked to this address.";
+  }
+  if (typeof acc !== "string") {
+    return "There is no vesting account linked to this address.";
+  }
+  if (isEthereumAddressValid(acc)) {
+    address = acc;
+  }
+  if (acc.startsWith("evmos") && isEvmosAddressValid(acc)) {
+    address = acc;
+  }
+  if (address === "") {
     return "There is no vesting account linked to this address.";
   }
 

--- a/apps/vesting/src/internal/fetch.ts
+++ b/apps/vesting/src/internal/fetch.ts
@@ -2,23 +2,23 @@
 // SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
 
 // import { EVMOS_BACKEND } from "evmos-wallet";
-// import { isValidAccount } from "../components/vesting/helpers";
+import { isValidAccount } from "../components/vesting/helpers";
 import { VestingResponse } from "./types";
 
 // TODO: change EVMOS_STAGING_BACKEND to EVMOS_BACKEND
 const EVMOS_STAGING_BACKEND = "https://goapi-staging.evmos.org";
 
-export const getVesting = async (account: string | false) => {
-  if (account === false || account === "undefined") {
+export const getVesting = async (account?: string | false) => {
+  if (account === false || account === undefined) {
     return "There is no vesting account linked to this address.";
   }
 
-  // const isValid = isValidAccount(account);
-  // if (!isValid || isValid === "undefined") {
-  //   return "There is no vesting account linked to this address.";
-  // }
+  const isValid = isValidAccount(account);
+  if (!isValid || isValid === undefined || typeof isValid !== "string") {
+    return "There is no vesting account linked to this address.";
+  }
   try {
-    const res = await fetch(`${EVMOS_STAGING_BACKEND}/v2/vesting/${account}`);
+    const res = await fetch(`${EVMOS_STAGING_BACKEND}/v2/vesting/${isValid}`);
     return res.json() as Promise<VestingResponse>;
   } catch (error) {
     return "Error while getting vesting account info";

--- a/apps/vesting/src/internal/fetch.ts
+++ b/apps/vesting/src/internal/fetch.ts
@@ -2,40 +2,17 @@
 // SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
 
 // import { EVMOS_BACKEND } from "evmos-wallet";
+
+import { isValidAccount } from "../components/vesting/helpers";
 import { VestingResponse } from "./types";
 
 // TODO: change EVMOS_STAGING_BACKEND to EVMOS_BACKEND
 const EVMOS_STAGING_BACKEND = "https://goapi-staging.evmos.org";
 
-const isEthereumAddressValid = (address: string): boolean => {
-  const ethereumAddressRegex = /^(0x)?[0-9a-fA-F]{40}$/;
-  return ethereumAddressRegex.test(address);
-};
-
-const isEvmosAddressValid = (address: string): boolean => {
-  const evmosAddressRegex = /^evmos[0-9a-zA-Z]{42}$/;
-  return evmosAddressRegex.test(address);
-};
-
 export const getVesting = async (account?: string) => {
-  const acc = account?.trim();
-  let address: string = "";
-  if (acc === undefined) {
-    return "There is no vesting account linked to this address.";
-  }
-  if (acc === null) {
-    return "There is no vesting account linked to this address.";
-  }
-  if (typeof acc !== "string") {
-    return "There is no vesting account linked to this address.";
-  }
-  if (isEthereumAddressValid(acc)) {
-    address = acc;
-  }
-  if (isEvmosAddressValid(acc)) {
-    address = acc;
-  }
-  if (address === "") {
+  const address = isValidAccount(account);
+
+  if (typeof address === "boolean" && address === false) {
     return "There is no vesting account linked to this address.";
   }
 

--- a/apps/vesting/src/internal/fetch.ts
+++ b/apps/vesting/src/internal/fetch.ts
@@ -3,14 +3,21 @@
 
 // import { EVMOS_BACKEND } from "evmos-wallet";
 
-import {
-  isEthereumAddressValid,
-  isEvmosAddressValid,
-} from "../components/vesting/helpers";
 import { VestingResponse } from "./types";
 
 // TODO: change EVMOS_STAGING_BACKEND to EVMOS_BACKEND
 const EVMOS_STAGING_BACKEND = "https://goapi-staging.evmos.org";
+
+const isEthereumAddressValid = (address: string): boolean => {
+  const ethereumAddressRegex = /^0x[0-9a-fA-F]{40}$/;
+  return ethereumAddressRegex.test(address);
+};
+
+const isEvmosAddressValid = (address: string): boolean => {
+  // TODO: this one is not working correctly
+  const evmosAddressRegex = /^evmos[0-9a-zA-Z]{42}$/;
+  return evmosAddressRegex.test(address);
+};
 
 export const getVesting = async (account?: string) => {
   const acc = account?.trim();
@@ -25,7 +32,7 @@ export const getVesting = async (account?: string) => {
   if (isEthereumAddressValid(acc)) {
     address = acc;
   }
-  if (acc.startsWith("evmos") && isEvmosAddressValid(acc)) {
+  if (isEvmosAddressValid(acc)) {
     address = acc;
   }
   if (address === "") {

--- a/apps/vesting/src/internal/fetch.ts
+++ b/apps/vesting/src/internal/fetch.ts
@@ -7,6 +7,16 @@ import { VestingResponse } from "./types";
 // TODO: change EVMOS_STAGING_BACKEND to EVMOS_BACKEND
 const EVMOS_STAGING_BACKEND = "https://goapi-staging.evmos.org";
 
+const isEthereumAddressValid = (address: string): boolean => {
+  const ethereumAddressRegex = /^(0x)?[0-9a-fA-F]{40}$/;
+  return ethereumAddressRegex.test(address);
+};
+
+const isEvmosAddressValid = (address: string): boolean => {
+  const evmosAddressRegex = /^evmos[0-9a-zA-Z]{42}$/;
+  return evmosAddressRegex.test(address);
+};
+
 export const getVesting = async (account?: string) => {
   const acc = account?.trim();
   let address: string = "";
@@ -19,10 +29,10 @@ export const getVesting = async (account?: string) => {
   if (typeof acc !== "string") {
     return "There is no vesting account linked to this address.";
   }
-  if (acc.startsWith("0x") && acc.length === 42) {
+  if (isEthereumAddressValid(acc)) {
     address = acc;
   }
-  if (acc.startsWith("evmos") && acc.length === 44) {
+  if (isEvmosAddressValid(acc)) {
     address = acc;
   }
   if (address === "") {

--- a/apps/vesting/src/internal/helpers.ts
+++ b/apps/vesting/src/internal/helpers.ts
@@ -1,0 +1,48 @@
+export const DEFAULT_VESTING_VALUES = {
+  locked: [
+    {
+      denom: "",
+      amount: "",
+    },
+  ],
+  unvested: [
+    {
+      denom: "",
+      amount: "",
+    },
+  ],
+  vested: [],
+  account: {
+    "@type": "",
+    base_vesting_account: {
+      base_account: {
+        address: "",
+        pub_key: "",
+        account_number: "",
+        sequence: "",
+      },
+      original_vesting: [{ denom: "", amount: "" }],
+      end_time: "",
+    },
+    funder_address: "",
+    start_time: "",
+    lockup_periods: [
+      {
+        length: "",
+        amount: {
+          denom: "",
+          amount: "",
+        },
+      },
+    ],
+    vesting_periods: [
+      {
+        length: "",
+        amount: {
+          denom: "",
+          amount: "",
+        },
+      },
+    ],
+  },
+};

--- a/apps/vesting/src/internal/hooks/useVesting.tsx
+++ b/apps/vesting/src/internal/hooks/useVesting.tsx
@@ -1,0 +1,45 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
+
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { getVesting } from "../fetch";
+import { VestingAccountDetail } from "../types";
+
+export const useVestingAccounts = (account?: string) => {
+  const vestingResponse = useQuery({
+    queryKey: ["vesting", account],
+    queryFn: () => getVesting(account),
+  });
+
+  const vestingDetails = useMemo(() => {
+    let temp: VestingAccountDetail = {
+      accountAddress: "",
+      funderAddress: "",
+      unvestedAmount: "",
+      originalVestingAmount: "",
+    };
+    if (vestingResponse.data !== undefined) {
+      if (typeof vestingResponse.data === "string") {
+        return "There is no vesting account linked to this address.";
+      }
+      temp = {
+        accountAddress:
+          vestingResponse.data.account.base_vesting_account.base_account
+            .address,
+        funderAddress: vestingResponse.data.account.funder_address,
+        unvestedAmount: vestingResponse.data.unvested[0].amount,
+        originalVestingAmount:
+          vestingResponse.data.account.base_vesting_account.original_vesting[0]
+            .amount,
+      };
+    }
+    return temp;
+  }, [vestingResponse]);
+
+  return {
+    vestingDetails: vestingDetails,
+    loading: vestingResponse.isLoading,
+    error: vestingResponse.error,
+  };
+};

--- a/apps/vesting/src/internal/hooks/useVesting.tsx
+++ b/apps/vesting/src/internal/hooks/useVesting.tsx
@@ -6,7 +6,7 @@ import { useMemo } from "react";
 import { getVesting } from "../fetch";
 import { VestingAccountDetail } from "../types";
 
-export const useVestingAccounts = (account: string | false) => {
+export const useVestingAccounts = (account?: string | false) => {
   const vestingResponse = useQuery({
     queryKey: ["vesting", account],
     queryFn: () => getVesting(account),

--- a/apps/vesting/src/internal/hooks/useVesting.tsx
+++ b/apps/vesting/src/internal/hooks/useVesting.tsx
@@ -6,7 +6,7 @@ import { useMemo } from "react";
 import { getVesting } from "../fetch";
 import { VestingAccountDetail } from "../types";
 
-export const useVestingAccounts = (account?: string | false) => {
+export const useVestingAccounts = (account?: string) => {
   const vestingResponse = useQuery({
     queryKey: ["vesting", account],
     queryFn: () => getVesting(account),

--- a/apps/vesting/src/internal/hooks/useVesting.tsx
+++ b/apps/vesting/src/internal/hooks/useVesting.tsx
@@ -6,7 +6,7 @@ import { useMemo } from "react";
 import { getVesting } from "../fetch";
 import { VestingAccountDetail } from "../types";
 
-export const useVestingAccounts = (account?: string) => {
+export const useVestingAccounts = (account: string | false) => {
   const vestingResponse = useQuery({
     queryKey: ["vesting", account],
     queryFn: () => getVesting(account),

--- a/apps/vesting/src/internal/types.ts
+++ b/apps/vesting/src/internal/types.ts
@@ -1,0 +1,51 @@
+type LockedResponse = {
+  denom: string;
+  amount: string;
+};
+
+type UnvestedResponse = {
+  denom: string;
+  amount: string;
+};
+
+type AccountResponse = {
+  "@type": string;
+  base_vesting_account: {
+    base_account: {
+      address: string;
+      pub_key: string;
+      account_number: string;
+      sequence: string;
+    };
+    original_vesting: {
+      denom: string;
+      amount: string;
+    }[];
+    end_time: string;
+  };
+  funder_address: string;
+  start_time: string;
+  lockup_periods: {
+    length: string;
+    amount: { denom: string; amount: string }[];
+  }[];
+  vesting_periods: {
+    length: string;
+    amount: { denom: string; amount: string }[];
+  }[];
+};
+
+export interface VestingResponse {
+  locked: LockedResponse[];
+  unvested: UnvestedResponse[];
+  vested: [];
+  account: AccountResponse;
+}
+
+// TODO: use Pick
+export type VestingAccountDetail = {
+  accountAddress: string;
+  funderAddress: string;
+  unvestedAmount: string;
+  originalVestingAmount: string;
+};

--- a/apps/vesting/src/internal/types.ts
+++ b/apps/vesting/src/internal/types.ts
@@ -42,10 +42,9 @@ export interface VestingResponse {
   account: AccountResponse;
 }
 
-// TODO: use Pick
 export type VestingAccountDetail = {
-  accountAddress: string;
-  funderAddress: string;
-  unvestedAmount: string;
-  originalVestingAmount: string;
+  accountAddress: VestingResponse["account"]["base_vesting_account"]["base_account"]["address"];
+  funderAddress: VestingResponse["account"]["funder_address"];
+  unvestedAmount: VestingResponse["unvested"][0]["amount"];
+  originalVestingAmount: VestingResponse["account"]["base_vesting_account"]["original_vesting"][0]["amount"];
 };

--- a/packages/ui-helpers/src/ViewExplorer.tsx
+++ b/packages/ui-helpers/src/ViewExplorer.tsx
@@ -17,7 +17,7 @@ export const ViewExplorer = ({
       target="_blank"
       rel="noreferrer"
       href={`${explorerTxUrl}/${txHash}`}
-      className="flex items-center space-x-2 text-sm"
+      className="flex items-center space-x-2 text-sm w-fit"
     >
       <p>{text}</p>
       <ExternalLinkIcon width={18} height={18} />


### PR DESCRIPTION
This PR Implements the `v2/vesting/${account}` endpoint. 
- It displays the vesting account information in account details. For now we are just using accountAddress and funderAddress
- For the clawback modal we use:
  -  accountAddress. 
  - Available for clawback → unvested.amount
  - Total vesting tokens → original_vesting.amount

The endpoint is returning `GET https://goapi-staging.evmos.org/v2/vesting/test net::ERR_FAILED 500` if the account is not a vesting one. 
We should check this. For now I just added a try/catch to handle it.