### PR TITLE
chore: move useEvmosBalance to evmos-wallet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+- (chore) #fse-681 | packages/evmos-wallet 1.0.10 apps/governance 1.0.16 | move useEvmosBalance to evmos-wallet
 - (feat) #fse-495 | packages/evmos-wallet 1.0.10 | Adding i18n with schummar library
 - (ci) #fse-668 | turbo.json | Updating config to be able to do a quick build using --filter for examample `yarn  build --filter mission-page`
 - (ci) #fse-675 | packages/playwright-config-custom 1.0.1 packages/vitest-config-custom 1.0.1 apps/assets 1.0.18 apps/governance 1.0.15 apps/mission 1.0.15 apps/staking 1.0.15 apps/vesting 1.0.13 packages/evmos-wallet 1.0.9 apps/helpers 1.0.5 packages/services 1.0.4 packages/tracker 1.0.3 packages/ui-helpers 1.0.9 | Refactoring playwright & vitest config

--- a/apps/governance/package.json
+++ b/apps/governance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "governance-page",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",

--- a/apps/governance/src/components/governance/proposalPage/vote/VoteButton.tsx
+++ b/apps/governance/src/components/governance/proposalPage/vote/VoteButton.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
 
 import { useState } from "react";
-import { EVMOS_SYMBOL } from "evmos-wallet";
+import { EVMOS_SYMBOL, useEvmosBalance } from "evmos-wallet";
 import { Modal, ErrorMessage, ConfirmButton } from "ui-helpers";
 import { useVote } from "../../modals/hooks/useVote";
 import IdContainer from "../../common/IdContainer";
@@ -10,7 +10,6 @@ import { VoteProps } from "../../common/types";
 import RadioElementContainer from "./RadioElementContainer";
 import { useSelector } from "react-redux";
 import { StoreType, MODAL_NOTIFICATIONS } from "evmos-wallet";
-import { useEvmosBalance } from "../../../../internal/common/functionality/hooks/useEvmosBalance";
 import { convertFromAtto, getReservedForFeeText } from "helpers";
 import { FEE_VOTE } from "constants-helper";
 import { BigNumber } from "ethers";

--- a/apps/governance/src/internal/common/functionality/hooks/fetch.ts
+++ b/apps/governance/src/internal/common/functionality/hooks/fetch.ts
@@ -1,22 +1,8 @@
 // Copyright Tharsis Labs Ltd.(Evmos)
 // SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
 
-import {
-  EVMOS_BACKEND,
-  EVMOS_MINIMAL_COIN_DENOM,
-  EVMOS_SYMBOL,
-} from "evmos-wallet";
-import { BalanceResponse, ERC20BalanceResponse } from "./types";
-
-export const getEvmosBalance = async (address: string) => {
-  if (address === "" || address == undefined || address == null) {
-    return { balance: { denom: "", amount: "" } };
-  }
-  const res = await fetch(
-    `${EVMOS_BACKEND}/BalanceByDenom/${EVMOS_SYMBOL}/${address}/${EVMOS_MINIMAL_COIN_DENOM}`
-  );
-  return res.json() as Promise<BalanceResponse>;
-};
+import { EVMOS_BACKEND } from "evmos-wallet";
+import { ERC20BalanceResponse } from "./types";
 
 export const getAssets = async () => {
   const res = await fetch(`${EVMOS_BACKEND}/ERC20ModuleBalance`);

--- a/apps/governance/src/internal/common/functionality/hooks/types.ts
+++ b/apps/governance/src/internal/common/functionality/hooks/types.ts
@@ -23,10 +23,3 @@ export type ERC20Element = {
 export type ERC20BalanceResponse = {
   balance: ERC20Element[];
 };
-
-export type BalanceResponse = {
-  balance: {
-    amount: string;
-    denom: string;
-  };
-};

--- a/apps/mission/src/internal/types.ts
+++ b/apps/mission/src/internal/types.ts
@@ -144,13 +144,6 @@ export type ERC20BalanceResponse = {
   balance: ERC20Element[];
 };
 
-export type BalanceResponse = {
-  balance: {
-    amount: string;
-    denom: string;
-  };
-};
-
 type AmountProposal = {
   denom: string;
   amount: string;

--- a/packages/evmos-wallet/package.json
+++ b/packages/evmos-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evmos-wallet",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "sideEffects": [
     "**/*.css"
   ],

--- a/packages/evmos-wallet/src/index.tsx
+++ b/packages/evmos-wallet/src/index.tsx
@@ -93,3 +93,4 @@ export {
 } from "./internal/wallet/functionality/metamask/metamaskHelpers";
 
 export { queryPubKey } from "./internal/wallet/functionality/pubkey";
+export { useEvmosBalance } from "./internal/wallet/functionality/hooks/useEvmosBalance";

--- a/packages/evmos-wallet/src/internal/wallet/functionality/fetch.ts
+++ b/packages/evmos-wallet/src/internal/wallet/functionality/fetch.ts
@@ -1,6 +1,14 @@
 // Copyright Tharsis Labs Ltd.(Evmos)
 // SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
 
+import {
+  EVMOS_BACKEND,
+  EVMOS_MINIMAL_COIN_DENOM,
+  EVMOS_SYMBOL,
+} from "./networkConfig";
+
+import { BalanceResponse } from "./types";
+
 export async function fetchWithTimeout(
   resource: string,
   options: RequestInit & { timeout?: number } = {}
@@ -15,3 +23,13 @@ export async function fetchWithTimeout(
   clearTimeout(id);
   return response;
 }
+
+export const getEvmosBalance = async (address: string) => {
+  if (address === "" || address == undefined || address == null) {
+    return { balance: { denom: "", amount: "" } };
+  }
+  const res = await fetch(
+    `${EVMOS_BACKEND}/BalanceByDenom/${EVMOS_SYMBOL}/${address}/${EVMOS_MINIMAL_COIN_DENOM}`
+  );
+  return res.json() as Promise<BalanceResponse>;
+};

--- a/packages/evmos-wallet/src/internal/wallet/functionality/hooks/useEvmosBalance.ts
+++ b/packages/evmos-wallet/src/internal/wallet/functionality/hooks/useEvmosBalance.ts
@@ -3,10 +3,11 @@
 
 import { useSelector } from "react-redux";
 import { useQuery } from "@tanstack/react-query";
-import { StoreType } from "evmos-wallet";
+import { StoreType } from "../../../../redux/Store";
 import { BigNumber } from "ethers";
-import { getEvmosBalance } from "./fetch";
-import { BalanceResponse } from "./types";
+import { getEvmosBalance } from "../fetch";
+import { BalanceResponse } from "../types";
+
 export const useEvmosBalance = () => {
   const value = useSelector((state: StoreType) => state.wallet.value);
 

--- a/packages/evmos-wallet/src/internal/wallet/functionality/types.ts
+++ b/packages/evmos-wallet/src/internal/wallet/functionality/types.ts
@@ -1,0 +1,9 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
+
+export type BalanceResponse = {
+  balance: {
+    amount: string;
+    denom: string;
+  };
+};


### PR DESCRIPTION
This PR move the useEvmosBalance hook to the `evmos-wallet` package to be shared in all other packagaes and apps