### PR TITLE
fix: add disable to processing button

### DIFF
--- a/apps/mission/src/components/copilot/steps/setUpAccount/buttons/ButtonCopilot.tsx
+++ b/apps/mission/src/components/copilot/steps/setUpAccount/buttons/ButtonCopilot.tsx
@@ -34,7 +34,8 @@ const STYLE2 = {
 const STYLE3 = {
   [STEP_STATUS.CURRENT]: "bg-red hover:bg-red1 ",
   [STEP_STATUS.DONE]: "pointer-events-none bg-[#31B886]",
-  [STEP_STATUS.PROCESSING]: "bg-red hover:bg-red1",
+  [STEP_STATUS.PROCESSING]:
+    "bg-red hover:bg-red1 pointer-events-none opacity-70",
 };
 
 export const ButtonCopilot = ({ props }: { props: ButtonProps }) => {


### PR DESCRIPTION
When the button has the status processing the user should not be able to click on it. 