### PR TITLE
chore: Card provider and crypto swap topup events 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+- (chore) | packages/copilot 1.0.4 packages/tracker 1.0.6 | Track card provider and crypto swap events
 - (chore) | apps/governance 1.0.21 apps/assets 1.0.23 apps/mission 1.0.20 apps/staking 1.0.19 apps/vesting 1.0.17 packages/icons 1.0.5 packages/copilot 1.0.3 packages/eslint-config-custom 1.0.4 | Add c14 and cypherD support
 
 ## 1.1.4 - 2023-08-03

--- a/packages/copilot/package.json
+++ b/packages/copilot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copilot",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "type": "module",

--- a/packages/copilot/src/copilot/steps/topUp/Intro.tsx
+++ b/packages/copilot/src/copilot/steps/topUp/Intro.tsx
@@ -3,7 +3,11 @@
 
 import { Dispatch, SetStateAction } from "react";
 import { CreditCardsIcon, EthereumIcon } from "icons";
-import { CLICK_ON_TOP_UP_WITH_CARD_COPILOT, useTracker } from "tracker";
+import {
+  CLICK_ON_TOP_UP_WITH_CARD_COPILOT,
+  useTracker,
+  CLICK_ON_TOP_UP_WITH_CRYPTO_COPILOT,
+} from "tracker";
 import { TranslationContextProvider } from "schummar-translate/react";
 import { t } from "../../../locales/translate";
 export const Intro = ({
@@ -11,18 +15,22 @@ export const Intro = ({
 }: {
   setTopUpType: Dispatch<SetStateAction<string>>;
 }) => {
-  const { handlePreClickAction } = useTracker(
+  const { handlePreClickAction: trackCardTopUp } = useTracker(
     CLICK_ON_TOP_UP_WITH_CARD_COPILOT
+  );
+
+  const { handlePreClickAction: trackCryptoTopUp } = useTracker(
+    CLICK_ON_TOP_UP_WITH_CRYPTO_COPILOT
   );
 
   const handleCardOnClick = () => {
     setTopUpType("card");
-    handlePreClickAction();
+    trackCardTopUp();
   };
 
   const handleCryptoOnClick = () => {
     setTopUpType("crypto");
-    handlePreClickAction();
+    trackCryptoTopUp();
   };
 
   return (

--- a/packages/copilot/src/copilot/steps/topUp/ProviderDropdown.tsx
+++ b/packages/copilot/src/copilot/steps/topUp/ProviderDropdown.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Dispatch, SetStateAction } from "react";
 import { DropdownArrow, TransakIcon, C14Icon } from "icons";
 import { t } from "../../../locales/translate";
+import { useTracker, CLICK_ON_DIFFERENT_ON_RAMP } from "tracker";
 
 export type DropdownOption = {
   name: string;
@@ -38,12 +39,17 @@ export default function ProviderDropwdown({
     };
   }, []);
 
+  const { handlePreClickAction: handleDifferentOnRampClick } = useTracker(
+    CLICK_ON_DIFFERENT_ON_RAMP
+  );
+
   const handleInputClick = (e: React.MouseEvent<HTMLElement>) => {
     e.stopPropagation();
     setShowMenu(!showMenu);
   };
 
   const onItemClick = (option: DropdownOption) => {
+    handleDifferentOnRampClick({ onRampType: option.value });
     setProvider(option);
   };
 

--- a/packages/tracker/package.json
+++ b/packages/tracker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tracker",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "type": "module",

--- a/packages/tracker/src/constants.ts
+++ b/packages/tracker/src/constants.ts
@@ -124,6 +124,8 @@ export const CLICK_ON_TOP_UP_WITH_CRYPTO_COPILOT =
   "Top up with “Cryptocurrencies” inside Copilot";
 // with transak
 export const CLICK_ON_BUY_NOW_COPILOT = "Click on “Buy now” inside Copilot";
+export const CLICK_ON_DIFFERENT_ON_RAMP =
+  "Click on different On-Ramp options inside Copilot";
 export const CLICK_ON_NEXT_STEPS_COPILOT =
   "Click on “Next Steps” after topping up inside Copilot";
 export const CLICK_ON_INTERACT_WITH_DAPP_COPILOT =

--- a/packages/tracker/src/index.tsx
+++ b/packages/tracker/src/index.tsx
@@ -96,6 +96,7 @@ export { CLICK_ON_CONNECT_ACCOUNT_COPILOT } from "./constants";
 export { CLICK_ON_TOP_UP_YOUR_ACCOUNT_COPILOT } from "./constants";
 export { CLICK_ON_TOP_UP_WITH_CARD_COPILOT } from "./constants";
 export { CLICK_ON_TOP_UP_WITH_CRYPTO_COPILOT } from "./constants";
+export { CLICK_ON_DIFFERENT_ON_RAMP } from "./constants";
 export { CLICK_ON_BUY_NOW_COPILOT } from "./constants";
 export { CLICK_ON_NEXT_STEPS_COPILOT } from "./constants";
 export { CLICK_ON_INTERACT_WITH_DAPP_COPILOT } from "./constants";


### PR DESCRIPTION
This PR adds event tracking for when users change on-ramp providers and when users choose to onboard via cryptocurrency swap