### PR TITLE
fix: display tooltip only if the user hover above the icon

### DIFF
--- a/apps/assets/src/components/topBarButtons/common/AccountInformation.tsx
+++ b/apps/assets/src/components/topBarButtons/common/AccountInformation.tsx
@@ -1,7 +1,9 @@
 // Copyright Tharsis Labs Ltd.(Evmos)
 // SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
 
+import { Tooltip } from "ui-helpers";
 import { AddressesContainer } from "./AddressesContainer";
+import { InformationIcon } from "icons";
 
 export const AccountInformation = () => {
   return (
@@ -9,12 +11,11 @@ export const AccountInformation = () => {
       <div>
         <div className="flex items-center space-x-1">
           <h3 className="font-bold">Account information</h3>
-          {/* the hover is applied on all the height. We want it only in the icon */}
-          {/* <Tooltip
-          className="min-w-[10rem]"
-          element={<InformationIcon width={15} height={15} />}
-          text="The addresses below are the same but in different formats. We provide this information for you to quickly refer to your address in instances like depositing assets into your account."
-        /> */}
+          <Tooltip
+            className="min-w-[10rem]"
+            element={<InformationIcon width={15} height={15} />}
+            text="The addresses below are the same but in different formats. We provide this information for you to quickly refer to your address in instances like depositing assets into your account."
+          />
         </div>
       </div>
 

--- a/packages/ui-helpers/src/Tooltip.tsx
+++ b/packages/ui-helpers/src/Tooltip.tsx
@@ -11,11 +11,11 @@ export const Tooltip = ({
   className?: string;
 }) => {
   return (
-    <div className="group relative">
+    <div className="group flex relative">
       {element}
       <span
-        className={`text-pearl absolute left-0 z-[40] m-4 mx-auto -translate-x-1/2 break-words 
-        rounded-md bg-black p-1 px-1 text-center text-xs font-normal opacity-0 transition-opacity group-hover:opacity-100 ${
+        className={`text-pearl absolute left-0 z-[40] m-4 mx-auto -translate-x-1/2 break-words pointer-events-none
+        rounded-md bg-black p-1 px-1 text-center text-[9px] font-normal opacity-0 transition-opacity group-hover:opacity-100 ${
           className !== undefined ? className : "max-w-[6rem]"
         } `}
       >


### PR DESCRIPTION
# 🧙 Description

Fix display tooltip. It was showing the description if the user was hovering the content instead of only the icon.

Ticket

## ✅ Checklist

- [ ] Acceptance Criteria described in the ticket are met
- [ ] Texts and strings are in the related i18n file
- [ ] Utilities have unit tests
- [ ] User stories and functionalities have integration or e2e tests
- [ ] Related packages.json are upgraded
- [ ] Changelog is updated
