### PR TITLE
chore: release v1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+## 1.2.2 - 2023-09-04
+
 - (fix) | apps/assets 1.0.27 apps/vesting 1.0.20 apps/governance 1.0.25 apps/mission 1.0.23 apps/staking 1.0.22 | Remove semicolon
 - (fix) apps/assets 1.0.26 | packages/evmos-wallet 1.0.16 | Fix erc20 convert issue
 - (fix) apps/copilot 1.0.6 | Fixing copilot wallet connection issue

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evmos-apps",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "license": "SEE LICENSE IN LICENSE",
   "author": "Tharsis Labs Ltd.(Evmos)",
   "private": true,


### PR DESCRIPTION
# 🧙 Description

This PR releases v1.2.2 of the dashboard

## Notable changes:

- apps/assets 1.0.27 apps/vesting 1.0.20 apps/governance 1.0.25 apps/mission 1.0.23 apps/staking 1.0.22 | Remove semicolon
- (apps/assets 1.0.26 | packages/evmos-wallet 1.0.16 | Fix erc20 convert issue
- (apps/copilot 1.0.6 | Fixing copilot wallet connection issue
