### PR TITLE
fix: sizing for modal-black

### DIFF
--- a/packages/ui-helpers/src/ModalWithTransitions.tsx
+++ b/packages/ui-helpers/src/ModalWithTransitions.tsx
@@ -75,11 +75,11 @@ export const ModalWithTransitions = ({
           >
             <Dialog.Panel
               className={cx(
-                "relative transform max-h-full rounded-lg text-left transition-all  pointer-events-auto",
+                "relative transform max-h-full rounded-lg text-left transition-all pointer-events-auto",
                 {
                   "bg-pearl1 shadow-xl md:min-w-[400px] max-w-[850px]":
                     variant === "default",
-                  "bg-black-900 shadow-custom-sm px-6 pt-6 pb-16 text-white w-full max-w-md":
+                  "bg-black-900 shadow-custom-sm px-6 pt-6 pb-16 text-white w-full max-w-md overflow-auto":
                     variant === "modal-black",
                 },
               )}


### PR DESCRIPTION
# 🧙 Description

Add overflow-auto for modal-black 

ERROR: 
![image](https://github.com/evmos/apps/assets/40247040/9b041353-9219-4be6-a30d-9daf82560c8e)

FIX: scrollable
![Screenshot 2023-09-22 at 16 41 14](https://github.com/evmos/apps/assets/40247040/67f5849b-903c-4940-bc0c-770e3e7ebb0c)


Ticket #fse-620

## ✅ Checklist

- [ ] Acceptance Criteria described in the ticket are met
- [ ] Texts and strings are in the related i18n file
- [ ] Utilities have unit tests
- [ ] User stories and functionalities have integration or e2e tests
- [ ] Related packages.json are upgraded
- [ ] Changelog is updated
