### PR TITLE
chore: use text param

### DIFF
--- a/apps/assets/src/components/topBarButtons/request/ReceiveContent.tsx
+++ b/apps/assets/src/components/topBarButtons/request/ReceiveContent.tsx
@@ -115,7 +115,7 @@ export const ReceiveContent = ({
                 <button
                   onClick={() => {
                     void navigator.share({
-                      url: sender ?? "",
+                      text: sender ?? "",
                       title: "Wallet Address",
                     });
                     sendEvent(CLICK_ON_SHARE_QR_CODE);


### PR DESCRIPTION
# 🧙 Description

Use text param in share API when sharing wallet address!