### PR TITLE
fix: native token transfer for safe apps

### DIFF
--- a/apps/assets/src/components/topBarButtons/receipt/ReceiptModal.tsx
+++ b/apps/assets/src/components/topBarButtons/receipt/ReceiptModal.tsx
@@ -8,6 +8,7 @@ import { ModalWithTransitions } from "ui-helpers";
 
 import { ReceiptModalContent } from "./ReceiptModalContent";
 import { ModalProps, useModal } from "helpers";
+import { useAccount } from "wagmi";
 
 const ReceiptModalSchema = z.object({
   hash: HexSchema,
@@ -20,7 +21,8 @@ export const useReceiptModal = () => useModal("receipt", ReceiptModalSchema);
 
 export const ReceiptModal = () => {
   const { isOpen, setIsOpen, modalProps } = useReceiptModal();
-  return (
+  const { connector } = useAccount();
+  return connector?.id !== "safe" ? (
     <ModalWithTransitions
       show={isOpen}
       setShow={setIsOpen}
@@ -28,5 +30,7 @@ export const ReceiptModal = () => {
     >
       {modalProps && <ReceiptModalContent {...modalProps} />}
     </ModalWithTransitions>
+  ) : (
+    <></>
   );
 };

--- a/packages/evmos-wallet/src/registry-actions/transfers/prepare-evm-transfer.ts
+++ b/packages/evmos-wallet/src/registry-actions/transfers/prepare-evm-transfer.ts
@@ -34,5 +34,8 @@ export const writeEvmTransfer = async ({
     amount,
   });
 
+  //Safe apps can not have data as undefined
+  if (!response.tx.data) response.tx.data = "0x";
+
   return sendTransaction(response.tx);
 };


### PR DESCRIPTION
# 🧙 Description
There was an issue when transferring token in the assets page using evmos safe. 
![image](https://github.com/evmos/apps/assets/65896721/2168f75d-722c-4c54-8ead-685a54ab7f46)

## Reason
Safe interprets tx data as incorrect when one of the main properties are _**undefined**_.
![image](https://github.com/evmos/apps/assets/65896721/361aeed9-70f0-4604-8c81-4aae4c16ccdb)

Therefore adding '0x' value for any null / undefined data property.

However, after the transfer safe user gets error message even for successful transaction.
![image](https://github.com/evmos/apps/assets/65896721/6bd32ab9-6c66-4905-a023-3d40e599b7a8)


That is because **safe-apps-sdk** returns safeTxHash instead of ethereum TxHash. Safe apps are used as multisignature accounts and they require multiple users to confirm the message, hence why there is no ethereum tx hash formed yet.

For now I propose to keep transaction receipt modal hidden (current PR) or greet safe users with a new modal which informs to check transaction status in the safe.

Users will still see the safe transaction status in the popup produced by safe:
![image](https://github.com/evmos/apps/assets/65896721/8933671d-759b-4599-ae84-57c4c5a60cfa)


## ✅ Checklist

- [ ] Acceptance Criteria described in the ticket are met
- [ ] Texts and strings are in the related i18n file
- [ ] Utilities have unit tests
- [ ] User stories and functionalities have integration or e2e tests
- [ ] Related packages.json are upgraded
- [ ] Changelog is updated
