### PR TITLE
Fix: withdraw for safe

### DIFF
--- a/apps/assets/src/components/asset/modals/transactions/contracts/hooks/useWEVMOS.ts
+++ b/apps/assets/src/components/asset/modals/transactions/contracts/hooks/useWEVMOS.ts
@@ -48,7 +48,7 @@ export function useWEVMOS() {
         args: [amount.toBigInt()],
         account: hexAddress as `0x${string}`,
       });
-      await writeContract(request);
+      return await writeContract(request);
     }
   }
 

--- a/apps/assets/src/components/asset/modals/transactions/contracts/hooks/useWEVMOS.ts
+++ b/apps/assets/src/components/asset/modals/transactions/contracts/hooks/useWEVMOS.ts
@@ -28,16 +28,15 @@ export function useWEVMOS() {
   ) {
     // prepareWriteTransaction throws revert error for safe if account property is not of EOA type
     if (connectorId === "safe") {
-      const encodedData = encodeFunctionData({
-        abi: WETH_ABI,
-        functionName: "withdraw",
-        args: [amount.toBigInt()],
-      });
       return await sendTransaction({
         to: WEVMOS_CONTRACT_ADDRESS,
         account: hexAddress as `0x${string}`,
         value: 0n,
-        data: encodedData,
+        data: encodeFunctionData({
+          abi: WETH_ABI,
+          functionName: "withdraw",
+          args: [amount.toBigInt()],
+        }),
       });
     } else {
       const { request } = await prepareWriteContract({

--- a/apps/assets/src/components/asset/modals/transactions/contracts/hooks/useWEVMOS.ts
+++ b/apps/assets/src/components/asset/modals/transactions/contracts/hooks/useWEVMOS.ts
@@ -1,8 +1,13 @@
 import WETH_ABI from "../../contracts/abis/WEVMOS/WEVMOS.json";
 import { WEVMOS_CONTRACT_ADDRESS } from "../../../constants";
-import { prepareWriteContract, writeContract } from "wagmi/actions";
+import {
+  prepareWriteContract,
+  sendTransaction,
+  writeContract,
+} from "wagmi/actions";
 
 import { BigNumber } from "@ethersproject/bignumber";
+import { encodeFunctionData } from "viem";
 
 export function useWEVMOS() {
   async function deposit(amount: BigNumber, hexAddress: string) {
@@ -16,16 +21,35 @@ export function useWEVMOS() {
     return await writeContract(request);
   }
 
-  async function withdraw(amount: BigNumber, hexAddress: string) {
-    const { request } = await prepareWriteContract({
-      address: WEVMOS_CONTRACT_ADDRESS,
-      abi: WETH_ABI,
-      functionName: "withdraw",
-      value: 0n,
-      args: [amount.toBigInt()],
-      account: hexAddress as `0x${string}`,
-    });
-    return await writeContract(request);
+  async function withdraw(
+    amount: BigNumber,
+    hexAddress: string,
+    connectorId: string | undefined
+  ) {
+    // prepareWriteTransaction throws revert error for safe if account property is not of EOA type
+    if (connectorId === "safe") {
+      const encodedData = encodeFunctionData({
+        abi: WETH_ABI,
+        functionName: "withdraw",
+        args: [amount.toBigInt()],
+      });
+      return await sendTransaction({
+        to: WEVMOS_CONTRACT_ADDRESS,
+        account: hexAddress as `0x${string}`,
+        value: 0n,
+        data: encodedData,
+      });
+    } else {
+      const { request } = await prepareWriteContract({
+        address: WEVMOS_CONTRACT_ADDRESS,
+        abi: WETH_ABI,
+        functionName: "withdraw",
+        value: 0n,
+        args: [amount.toBigInt()],
+        account: hexAddress as `0x${string}`,
+      });
+      await writeContract(request);
+    }
   }
 
   return {

--- a/apps/assets/src/components/asset/modals/transactions/contracts/hooks/useWEVMOS.ts
+++ b/apps/assets/src/components/asset/modals/transactions/contracts/hooks/useWEVMOS.ts
@@ -26,7 +26,7 @@ export function useWEVMOS() {
     hexAddress: string,
     connectorId: string | undefined
   ) {
-    // prepareWriteTransaction throws revert error for safe if account property is not of EOA type
+    // prepareWriteContract or writeContract throws revert error for safe if account property is not of EOA type
     if (connectorId === "safe") {
       return await sendTransaction({
         to: WEVMOS_CONTRACT_ADDRESS,

--- a/apps/assets/src/components/asset/modals/transactions/hooks/useConvert.ts
+++ b/apps/assets/src/components/asset/modals/transactions/hooks/useConvert.ts
@@ -20,17 +20,19 @@ import {
 import { GENERATING_TX_NOTIFICATIONS } from "../../../../../internal/asset/functionality/transactions/errors";
 import { useWEVMOS } from "../contracts/hooks/useWEVMOS";
 import { parseUnits } from "@ethersproject/units";
+import { useAccount } from "wagmi";
 
 const wrapEvmos = "EVMOS <> WEVMOS";
 const unwrapEvmos = "WEVMOS <> EVMOS";
 export const useConvert = (useConvertProps: ConvertProps) => {
   const wallet = useSelector((state: StoreType) => state.wallet.value);
+  const { connector } = useAccount();
   const dispatch = useDispatch();
 
   const { deposit, withdraw } = useWEVMOS();
 
   const { handlePreClickAction: clickConfirmWrapTx } = useTracker(
-    CLICK_BUTTON_CONFIRM_WRAP_TX,
+    CLICK_BUTTON_CONFIRM_WRAP_TX
   );
 
   const { handlePreClickAction: successfulTx } = useTracker(SUCCESSFUL_WRAP_TX);
@@ -61,7 +63,7 @@ export const useConvert = (useConvertProps: ConvertProps) => {
     }
     const amount = parseUnits(
       useConvertProps.inputValue,
-      BigNumber.from(useConvertProps.item.decimals),
+      BigNumber.from(useConvertProps.item.decimals)
     );
     if (amount.gt(useConvertProps.balance.balanceFrom)) {
       return;
@@ -73,7 +75,7 @@ export const useConvert = (useConvertProps: ConvertProps) => {
         const res = await deposit(amount, wallet.evmosAddressEthFormat);
 
         dispatch(
-          snackBroadcastSuccessful(res.hash, "www.mintscan.io/evmos/txs/"),
+          snackBroadcastSuccessful(res.hash, "www.mintscan.io/evmos/txs/")
         );
         successfulTx({
           txHash: res.hash,
@@ -98,10 +100,14 @@ export const useConvert = (useConvertProps: ConvertProps) => {
       try {
         useConvertProps.setDisabled(true);
 
-        const res = await withdraw(amount, wallet.evmosAddressEthFormat);
+        const res = await withdraw(
+          amount,
+          wallet.evmosAddressEthFormat,
+          connector?.id
+        );
 
         dispatch(
-          snackBroadcastSuccessful(res.hash, "www.mintscan.io/evmos/txs/"),
+          snackBroadcastSuccessful(res.hash, "www.mintscan.io/evmos/txs/")
         );
         successfulTx({
           txHash: res.hash,


### PR DESCRIPTION
# 🧙 Description
Withdrawal TX preparation does not work non-EOA accounts (aka contracts) - it shows execution reverted even though there is no reason for it to be reverted.

![image](https://github.com/evmos/apps/assets/65896721/6cd88784-0953-40ab-93ed-d34971fd0aaa)


I checked the contract - it reverts the function if the balance is lower than the withdrawal amount. However, safe has enough of it.
Also, I performed withdrawal transaction for safe using tx-builder - [and there were no problems](https://escan.live/tx/0x71983446fe9fd11d37ce23b1e7050e34909101db738dcc3362ea4a17f5202224).

## Solution:
**Encoding data** and sending it via **sendTransaction** function works with no issues. 
Just in case left this logic only for safe connector, hence why connector ID is passed to the withdraw function. 
![image](https://github.com/evmos/apps/assets/65896721/e2909684-d219-46a1-9853-1fcc94dd6346)


Ticket #

## ✅ Checklist

- [ ] Acceptance Criteria described in the ticket are met
- [ ] Texts and strings are in the related i18n file
- [ ] Utilities have unit tests
- [ ] User stories and functionalities have integration or e2e tests
- [ ] Related packages.json are upgraded
- [ ] Changelog is updated
