### PR TITLE
chore: pubkey & manifest.json fixes

### DIFF
--- a/apps/vesting/public/manifest.json
+++ b/apps/vesting/public/manifest.json
@@ -1,6 +1,7 @@
 {
   "short_name": "EvmosVesting",
   "name": "Evmos Vesting",
+  "description": "The vesting page allows users to create and fund evmos vesting accounts.",
   "icons": [
     {
       "src": "favicon.ico",

--- a/apps/vesting/src/components/vesting/header/Header.tsx
+++ b/apps/vesting/src/components/vesting/header/Header.tsx
@@ -1,7 +1,7 @@
 import { ConfirmButton, Modal } from "ui-helpers";
 import { SearchVesting } from "./SearchVesting";
 import { useSelector } from "react-redux";
-import { KEPLR_KEY, StoreType } from "evmos-wallet";
+import { StoreType } from "evmos-wallet";
 import { useState } from "react";
 import { FundVestingAccount } from "./FundVestingAccount";
 import { EnableVestingModal } from "./EnableVestingModal";
@@ -30,13 +30,13 @@ export const Header = () => {
             onClick={() => {
               setShowEnableModal(true);
             }}
-            disabled={!value.active || value.extensionName === KEPLR_KEY}
+            disabled={!value.active}
           />
           <ConfirmButton
             className="w-fit normal-case"
             text={t("fund.header.button.title")}
             onClick={handleConfirmClick}
-            disabled={!value.active || value.extensionName === KEPLR_KEY}
+            disabled={!value.active}
           />
         </div>
         <SearchVesting />

--- a/apps/vesting/src/internal/useVestingPrecompile.ts
+++ b/apps/vesting/src/internal/useVestingPrecompile.ts
@@ -20,7 +20,7 @@ export function useVestingPrecompile() {
         address: VESTING_CONTRACT_ADDRESS,
         abi: VestingABI,
         functionName: "createClawbackVestingAccount",
-
+        value: 0n,
         account: address.evmosAddressEthFormat as `0x${string}`,
         args: [funderAddress, vestingAddress, enableGovClawback],
       },

--- a/packages/evmos-wallet/src/wallet/components/WalletProvider.tsx
+++ b/packages/evmos-wallet/src/wallet/components/WalletProvider.tsx
@@ -7,7 +7,7 @@ import {
   notifySuccess,
 } from "../../internal/wallet/functionality/errors";
 import { truncateAddress } from "../../internal/wallet/style/format";
-import { store } from "../..";
+import { getActiveProviderKey, store } from "../..";
 import { resetWallet, setWallet } from "../redux/WalletSlice";
 import { ethToEvmos } from "@evmos/address-converter";
 import {
@@ -46,7 +46,7 @@ function Provider({ children }: WalletProviderProps) {
 
   useEffect(() => {
     const connectorId = connector?.id.toLowerCase();
-    if (!connectorId || !address || !pubkey) return;
+    if (!connectorId || !address || (!pubkey && getActiveProviderKey() !== "safe")) return;
     /**
      * TODO: this is to sync with the current wallet redux store
      * In a future PR I intent to remove this store
@@ -59,7 +59,7 @@ function Provider({ children }: WalletProviderProps) {
         extensionName: connectorId,
         evmosAddressEthFormat: address,
         evmosAddressCosmosFormat: ethToEvmos(address),
-        evmosPubkey: pubkey,
+        evmosPubkey: pubkey ?? "",
         osmosisPubkey: null,
         accountName: null,
       }),
@@ -67,7 +67,7 @@ function Provider({ children }: WalletProviderProps) {
   }, [isConnected, connector, pubkey, address]);
 
   useEffect(() => {
-    if (!pubkeyError) return;
+    if (!pubkeyError || getActiveProviderKey() === "safe") return;
     disconnect();
     notifyError(
       WALLET_NOTIFICATIONS.ErrorTitle,

--- a/packages/evmos-wallet/src/wallet/wagmi/usePubKey.ts
+++ b/packages/evmos-wallet/src/wallet/wagmi/usePubKey.ts
@@ -8,6 +8,7 @@ import { useEffect } from "react";
 import { signatureToPubkey } from "@hanchon/signature-to-pubkey";
 import { raise } from "helpers";
 import { keplrConnector } from "./connectors";
+import { getActiveProviderKey } from "../actions";
 const recoveryMessage = "generate_pubkey";
 const hashedMessage = Buffer.from(
   fromHex(hashMessage(recoveryMessage), "bytes"),
@@ -47,6 +48,10 @@ export const usePubKey = () => {
       const signature = await signMessageAsync({
         message: recoveryMessage,
       });
+
+      if(getActiveProviderKey() === "safe") {
+        return ""
+      }
 
       pubkey = signatureToPubkey(signature, hashedMessage);
       if (pubkey) return pubkey;


### PR DESCRIPTION
# 🧙 Description

This PR attempts to fix vesting app not working for safe. To do this we simply add a description field to the manifest.json file of the vesting application.

This PR also fixes a bug related to pubkey derivation of a connected account. We skip pubkey derivation if the connected wallet is safe
