### PR TITLE
chore: Use staking precompile

### DIFF
--- a/apps/staking/src/components/staking/modals/hooks/useUndelegations.tsx
+++ b/apps/staking/src/components/staking/modals/hooks/useUndelegations.tsx
@@ -5,8 +5,7 @@ import { useDispatch } from "react-redux";
 import { UndelegateProps } from "../types";
 import { parseUnits } from "@ethersproject/units";
 import { BigNumber } from "@ethersproject/bignumber";
-import { executeUndelegate } from "../../../../internal/staking/functionality/transactions/undelegate";
-import { snackExecuteIBCTransfer } from "evmos-wallet";
+import { GENERATING_TX_NOTIFICATIONS, snackBroadcastSuccessful, snackErrorGeneratingTx } from "evmos-wallet";
 
 import {
   CLICK_BUTTON_CONFIRM_UNDELEGATE,
@@ -14,6 +13,7 @@ import {
   SUCCESSFUL_TX_UNDELEGATE,
   UNSUCCESSFUL_TX_UNDELEGATE,
 } from "tracker";
+import { useStakingPrecompile } from "../../../../internal/staking/functionality/hooks/useStakingPrecompile";
 export const useUndelegation = (useUndelegateProps: UndelegateProps) => {
   const dispatch = useDispatch();
   const { handlePreClickAction } = useTracker(CLICK_BUTTON_CONFIRM_UNDELEGATE);
@@ -23,6 +23,9 @@ export const useUndelegation = (useUndelegateProps: UndelegateProps) => {
   const { handlePreClickAction: unsuccessfulTx } = useTracker(
     UNSUCCESSFUL_TX_UNDELEGATE,
   );
+
+  const {undelegate} = useStakingPrecompile()
+
   const handleConfirmButton = async () => {
     handlePreClickAction({
       wallet: useUndelegateProps?.wallet?.evmosAddressEthFormat,
@@ -45,25 +48,30 @@ export const useUndelegation = (useUndelegateProps: UndelegateProps) => {
 
     useUndelegateProps.setDisabled(true);
 
-    const res = await executeUndelegate(
-      useUndelegateProps.wallet,
-      useUndelegateProps.item.validatorAddress,
-      amount,
-    );
-    dispatch(snackExecuteIBCTransfer(res));
-    if (res.error === true) {
-      unsuccessfulTx({
-        errorMessage: res.message,
-        wallet: useUndelegateProps.wallet?.evmosAddressEthFormat,
-        provider: useUndelegateProps.wallet?.extensionName,
-        transaction: "unsuccessful",
-      });
-    } else {
+    try {
+      const res = await undelegate(
+        useUndelegateProps.wallet.evmosAddressEthFormat,
+        useUndelegateProps.item.validatorAddress,
+        amount,
+      );
+
+      dispatch(
+        snackBroadcastSuccessful(res.hash, "www.mintscan.io/evmos/txs/")
+      );
+  
       successfulTx({
-        txHash: res.txHash,
+        txHash: res.hash,
         wallet: useUndelegateProps.wallet?.evmosAddressEthFormat,
         provider: useUndelegateProps.wallet?.extensionName,
-        transaction: "successful",
+        transaction: "successful"
+      });
+    } catch (e) {
+      dispatch(snackErrorGeneratingTx());
+      unsuccessfulTx({
+        errorMessage: GENERATING_TX_NOTIFICATIONS.ErrorGeneratingTx,
+        wallet: useUndelegateProps.wallet?.evmosAddressEthFormat,
+        provider: useUndelegateProps.wallet?.extensionName,
+        transaction: "unsuccessful"
       });
     }
     useUndelegateProps.setShow(false);

--- a/apps/staking/src/internal/staking/functionality/abis/StakingABI.json
+++ b/apps/staking/src/internal/staking/functionality/abis/StakingABI.json
@@ -1,0 +1,992 @@
+[
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": true,
+				"internalType": "address",
+				"name": "grantee",
+				"type": "address"
+			},
+			{
+				"indexed": true,
+				"internalType": "address",
+				"name": "granter",
+				"type": "address"
+			},
+			{
+				"indexed": false,
+				"internalType": "string[]",
+				"name": "methods",
+				"type": "string[]"
+			},
+			{
+				"indexed": false,
+				"internalType": "uint256[]",
+				"name": "values",
+				"type": "uint256[]"
+			}
+		],
+		"name": "AllowanceChange",
+		"type": "event"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": true,
+				"internalType": "address",
+				"name": "grantee",
+				"type": "address"
+			},
+			{
+				"indexed": true,
+				"internalType": "address",
+				"name": "granter",
+				"type": "address"
+			},
+			{
+				"indexed": false,
+				"internalType": "string[]",
+				"name": "methods",
+				"type": "string[]"
+			},
+			{
+				"indexed": false,
+				"internalType": "uint256",
+				"name": "value",
+				"type": "uint256"
+			}
+		],
+		"name": "Approval",
+		"type": "event"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": true,
+				"internalType": "address",
+				"name": "delegatorAddress",
+				"type": "address"
+			},
+			{
+				"indexed": true,
+				"internalType": "string",
+				"name": "validatorAddress",
+				"type": "string"
+			},
+			{
+				"indexed": false,
+				"internalType": "uint256",
+				"name": "amount",
+				"type": "uint256"
+			},
+			{
+				"indexed": false,
+				"internalType": "uint256",
+				"name": "creationHeight",
+				"type": "uint256"
+			}
+		],
+		"name": "CancelUnbondingDelegation",
+		"type": "event"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": true,
+				"internalType": "address",
+				"name": "delegatorAddress",
+				"type": "address"
+			},
+			{
+				"indexed": true,
+				"internalType": "string",
+				"name": "validatorAddress",
+				"type": "string"
+			},
+			{
+				"indexed": false,
+				"internalType": "uint256",
+				"name": "amount",
+				"type": "uint256"
+			},
+			{
+				"indexed": false,
+				"internalType": "uint256",
+				"name": "newShares",
+				"type": "uint256"
+			}
+		],
+		"name": "Delegate",
+		"type": "event"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": true,
+				"internalType": "address",
+				"name": "delegatorAddress",
+				"type": "address"
+			},
+			{
+				"indexed": true,
+				"internalType": "string",
+				"name": "validatorSrcAddress",
+				"type": "string"
+			},
+			{
+				"indexed": true,
+				"internalType": "string",
+				"name": "validatorDstAddress",
+				"type": "string"
+			},
+			{
+				"indexed": false,
+				"internalType": "uint256",
+				"name": "amount",
+				"type": "uint256"
+			},
+			{
+				"indexed": false,
+				"internalType": "uint256",
+				"name": "completionTime",
+				"type": "uint256"
+			}
+		],
+		"name": "Redelegate",
+		"type": "event"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": true,
+				"internalType": "address",
+				"name": "grantee",
+				"type": "address"
+			},
+			{
+				"indexed": true,
+				"internalType": "address",
+				"name": "granter",
+				"type": "address"
+			},
+			{
+				"indexed": false,
+				"internalType": "string[]",
+				"name": "methods",
+				"type": "string[]"
+			}
+		],
+		"name": "Revocation",
+		"type": "event"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": true,
+				"internalType": "address",
+				"name": "delegatorAddress",
+				"type": "address"
+			},
+			{
+				"indexed": true,
+				"internalType": "string",
+				"name": "validatorAddress",
+				"type": "string"
+			},
+			{
+				"indexed": false,
+				"internalType": "uint256",
+				"name": "amount",
+				"type": "uint256"
+			},
+			{
+				"indexed": false,
+				"internalType": "uint256",
+				"name": "completionTime",
+				"type": "uint256"
+			}
+		],
+		"name": "Unbond",
+		"type": "event"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "grantee",
+				"type": "address"
+			},
+			{
+				"internalType": "address",
+				"name": "granter",
+				"type": "address"
+			},
+			{
+				"internalType": "string",
+				"name": "method",
+				"type": "string"
+			}
+		],
+		"name": "allowance",
+		"outputs": [
+			{
+				"internalType": "uint256",
+				"name": "remaining",
+				"type": "uint256"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "grantee",
+				"type": "address"
+			},
+			{
+				"internalType": "uint256",
+				"name": "amount",
+				"type": "uint256"
+			},
+			{
+				"internalType": "string[]",
+				"name": "methods",
+				"type": "string[]"
+			}
+		],
+		"name": "approve",
+		"outputs": [
+			{
+				"internalType": "bool",
+				"name": "approved",
+				"type": "bool"
+			}
+		],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "delegatorAddress",
+				"type": "address"
+			},
+			{
+				"internalType": "string",
+				"name": "validatorAddress",
+				"type": "string"
+			},
+			{
+				"internalType": "uint256",
+				"name": "amount",
+				"type": "uint256"
+			},
+			{
+				"internalType": "uint256",
+				"name": "creationHeight",
+				"type": "uint256"
+			}
+		],
+		"name": "cancelUnbondingDelegation",
+		"outputs": [
+			{
+				"internalType": "bool",
+				"name": "success",
+				"type": "bool"
+			}
+		],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "grantee",
+				"type": "address"
+			},
+			{
+				"internalType": "uint256",
+				"name": "amount",
+				"type": "uint256"
+			},
+			{
+				"internalType": "string[]",
+				"name": "methods",
+				"type": "string[]"
+			}
+		],
+		"name": "decreaseAllowance",
+		"outputs": [
+			{
+				"internalType": "bool",
+				"name": "approved",
+				"type": "bool"
+			}
+		],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "delegatorAddress",
+				"type": "address"
+			},
+			{
+				"internalType": "string",
+				"name": "validatorAddress",
+				"type": "string"
+			},
+			{
+				"internalType": "uint256",
+				"name": "amount",
+				"type": "uint256"
+			}
+		],
+		"name": "delegate",
+		"outputs": [
+			{
+				"internalType": "bool",
+				"name": "success",
+				"type": "bool"
+			}
+		],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "delegatorAddress",
+				"type": "address"
+			},
+			{
+				"internalType": "string",
+				"name": "validatorAddress",
+				"type": "string"
+			}
+		],
+		"name": "delegation",
+		"outputs": [
+			{
+				"internalType": "uint256",
+				"name": "shares",
+				"type": "uint256"
+			},
+			{
+				"components": [
+					{
+						"internalType": "string",
+						"name": "denom",
+						"type": "string"
+					},
+					{
+						"internalType": "uint256",
+						"name": "amount",
+						"type": "uint256"
+					}
+				],
+				"internalType": "struct Coin",
+				"name": "balance",
+				"type": "tuple"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "grantee",
+				"type": "address"
+			},
+			{
+				"internalType": "uint256",
+				"name": "amount",
+				"type": "uint256"
+			},
+			{
+				"internalType": "string[]",
+				"name": "methods",
+				"type": "string[]"
+			}
+		],
+		"name": "increaseAllowance",
+		"outputs": [
+			{
+				"internalType": "bool",
+				"name": "approved",
+				"type": "bool"
+			}
+		],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "delegatorAddress",
+				"type": "address"
+			},
+			{
+				"internalType": "string",
+				"name": "validatorSrcAddress",
+				"type": "string"
+			},
+			{
+				"internalType": "string",
+				"name": "validatorDstAddress",
+				"type": "string"
+			},
+			{
+				"internalType": "uint256",
+				"name": "amount",
+				"type": "uint256"
+			}
+		],
+		"name": "redelegate",
+		"outputs": [
+			{
+				"internalType": "int64",
+				"name": "completionTime",
+				"type": "int64"
+			}
+		],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "delegatorAddress",
+				"type": "address"
+			},
+			{
+				"internalType": "string",
+				"name": "srcValidatorAddress",
+				"type": "string"
+			},
+			{
+				"internalType": "string",
+				"name": "dstValidatorAddress",
+				"type": "string"
+			}
+		],
+		"name": "redelegation",
+		"outputs": [
+			{
+				"components": [
+					{
+						"internalType": "int64",
+						"name": "creationHeight",
+						"type": "int64"
+					},
+					{
+						"internalType": "int64",
+						"name": "completionTime",
+						"type": "int64"
+					},
+					{
+						"internalType": "uint256",
+						"name": "initialBalance",
+						"type": "uint256"
+					},
+					{
+						"internalType": "uint256",
+						"name": "sharesDst",
+						"type": "uint256"
+					}
+				],
+				"internalType": "struct RedelegationEntry[]",
+				"name": "entries",
+				"type": "tuple[]"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "delegatorAddress",
+				"type": "address"
+			},
+			{
+				"internalType": "string",
+				"name": "srcValidatorAddress",
+				"type": "string"
+			},
+			{
+				"internalType": "string",
+				"name": "dstValidatorAddress",
+				"type": "string"
+			},
+			{
+				"components": [
+					{
+						"internalType": "bytes",
+						"name": "key",
+						"type": "bytes"
+					},
+					{
+						"internalType": "uint64",
+						"name": "offset",
+						"type": "uint64"
+					},
+					{
+						"internalType": "uint64",
+						"name": "limit",
+						"type": "uint64"
+					},
+					{
+						"internalType": "bool",
+						"name": "countTotal",
+						"type": "bool"
+					},
+					{
+						"internalType": "bool",
+						"name": "reverse",
+						"type": "bool"
+					}
+				],
+				"internalType": "struct PageRequest",
+				"name": "pageRequest",
+				"type": "tuple"
+			}
+		],
+		"name": "redelegations",
+		"outputs": [
+			{
+				"components": [
+					{
+						"components": [
+							{
+								"internalType": "string",
+								"name": "delegatorAddress",
+								"type": "string"
+							},
+							{
+								"internalType": "string",
+								"name": "validatorSrcAddress",
+								"type": "string"
+							},
+							{
+								"internalType": "string",
+								"name": "validatorDstAddress",
+								"type": "string"
+							},
+							{
+								"components": [
+									{
+										"internalType": "int64",
+										"name": "creationHeight",
+										"type": "int64"
+									},
+									{
+										"internalType": "int64",
+										"name": "completionTime",
+										"type": "int64"
+									},
+									{
+										"internalType": "uint256",
+										"name": "initialBalance",
+										"type": "uint256"
+									},
+									{
+										"internalType": "uint256",
+										"name": "sharesDst",
+										"type": "uint256"
+									}
+								],
+								"internalType": "struct RedelegationEntry[]",
+								"name": "entries",
+								"type": "tuple[]"
+							}
+						],
+						"internalType": "struct Redelegation",
+						"name": "redelegation",
+						"type": "tuple"
+					},
+					{
+						"components": [
+							{
+								"components": [
+									{
+										"internalType": "int64",
+										"name": "creationHeight",
+										"type": "int64"
+									},
+									{
+										"internalType": "int64",
+										"name": "completionTime",
+										"type": "int64"
+									},
+									{
+										"internalType": "uint256",
+										"name": "initialBalance",
+										"type": "uint256"
+									},
+									{
+										"internalType": "uint256",
+										"name": "sharesDst",
+										"type": "uint256"
+									}
+								],
+								"internalType": "struct RedelegationEntry",
+								"name": "redelegationEntry",
+								"type": "tuple"
+							},
+							{
+								"internalType": "uint256",
+								"name": "balance",
+								"type": "uint256"
+							}
+						],
+						"internalType": "struct RedelegationEntryResponse[]",
+						"name": "entries",
+						"type": "tuple[]"
+					}
+				],
+				"internalType": "struct RedelegationResponse[]",
+				"name": "response",
+				"type": "tuple[]"
+			},
+			{
+				"components": [
+					{
+						"internalType": "bytes",
+						"name": "nextKey",
+						"type": "bytes"
+					},
+					{
+						"internalType": "uint64",
+						"name": "total",
+						"type": "uint64"
+					}
+				],
+				"internalType": "struct PageResponse",
+				"name": "pageResponse",
+				"type": "tuple"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "grantee",
+				"type": "address"
+			},
+			{
+				"internalType": "string[]",
+				"name": "methods",
+				"type": "string[]"
+			}
+		],
+		"name": "revoke",
+		"outputs": [
+			{
+				"internalType": "bool",
+				"name": "revoked",
+				"type": "bool"
+			}
+		],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "delegatorAddress",
+				"type": "address"
+			},
+			{
+				"internalType": "string",
+				"name": "validatorAddress",
+				"type": "string"
+			}
+		],
+		"name": "unbondingDelegation",
+		"outputs": [
+			{
+				"components": [
+					{
+						"internalType": "int64",
+						"name": "creationHeight",
+						"type": "int64"
+					},
+					{
+						"internalType": "int64",
+						"name": "completionTime",
+						"type": "int64"
+					},
+					{
+						"internalType": "uint256",
+						"name": "initialBalance",
+						"type": "uint256"
+					},
+					{
+						"internalType": "uint256",
+						"name": "balance",
+						"type": "uint256"
+					}
+				],
+				"internalType": "struct UnbondingDelegationEntry[]",
+				"name": "entries",
+				"type": "tuple[]"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "delegatorAddress",
+				"type": "address"
+			},
+			{
+				"internalType": "string",
+				"name": "validatorAddress",
+				"type": "string"
+			},
+			{
+				"internalType": "uint256",
+				"name": "amount",
+				"type": "uint256"
+			}
+		],
+		"name": "undelegate",
+		"outputs": [
+			{
+				"internalType": "int64",
+				"name": "completionTime",
+				"type": "int64"
+			}
+		],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "string",
+				"name": "validatorAddress",
+				"type": "string"
+			}
+		],
+		"name": "validator",
+		"outputs": [
+			{
+				"components": [
+					{
+						"internalType": "string",
+						"name": "operatorAddress",
+						"type": "string"
+					},
+					{
+						"internalType": "string",
+						"name": "consensusPubkey",
+						"type": "string"
+					},
+					{
+						"internalType": "bool",
+						"name": "jailed",
+						"type": "bool"
+					},
+					{
+						"internalType": "enum BondStatus",
+						"name": "status",
+						"type": "uint8"
+					},
+					{
+						"internalType": "uint256",
+						"name": "tokens",
+						"type": "uint256"
+					},
+					{
+						"internalType": "uint256",
+						"name": "delegatorShares",
+						"type": "uint256"
+					},
+					{
+						"internalType": "string",
+						"name": "description",
+						"type": "string"
+					},
+					{
+						"internalType": "int64",
+						"name": "unbondingHeight",
+						"type": "int64"
+					},
+					{
+						"internalType": "int64",
+						"name": "unbondingTime",
+						"type": "int64"
+					},
+					{
+						"internalType": "uint256",
+						"name": "commission",
+						"type": "uint256"
+					},
+					{
+						"internalType": "uint256",
+						"name": "minSelfDelegation",
+						"type": "uint256"
+					}
+				],
+				"internalType": "struct Validator",
+				"name": "validator",
+				"type": "tuple"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "string",
+				"name": "status",
+				"type": "string"
+			},
+			{
+				"components": [
+					{
+						"internalType": "bytes",
+						"name": "key",
+						"type": "bytes"
+					},
+					{
+						"internalType": "uint64",
+						"name": "offset",
+						"type": "uint64"
+					},
+					{
+						"internalType": "uint64",
+						"name": "limit",
+						"type": "uint64"
+					},
+					{
+						"internalType": "bool",
+						"name": "countTotal",
+						"type": "bool"
+					},
+					{
+						"internalType": "bool",
+						"name": "reverse",
+						"type": "bool"
+					}
+				],
+				"internalType": "struct PageRequest",
+				"name": "pageRequest",
+				"type": "tuple"
+			}
+		],
+		"name": "validators",
+		"outputs": [
+			{
+				"components": [
+					{
+						"internalType": "string",
+						"name": "operatorAddress",
+						"type": "string"
+					},
+					{
+						"internalType": "string",
+						"name": "consensusPubkey",
+						"type": "string"
+					},
+					{
+						"internalType": "bool",
+						"name": "jailed",
+						"type": "bool"
+					},
+					{
+						"internalType": "enum BondStatus",
+						"name": "status",
+						"type": "uint8"
+					},
+					{
+						"internalType": "uint256",
+						"name": "tokens",
+						"type": "uint256"
+					},
+					{
+						"internalType": "uint256",
+						"name": "delegatorShares",
+						"type": "uint256"
+					},
+					{
+						"internalType": "string",
+						"name": "description",
+						"type": "string"
+					},
+					{
+						"internalType": "int64",
+						"name": "unbondingHeight",
+						"type": "int64"
+					},
+					{
+						"internalType": "int64",
+						"name": "unbondingTime",
+						"type": "int64"
+					},
+					{
+						"internalType": "uint256",
+						"name": "commission",
+						"type": "uint256"
+					},
+					{
+						"internalType": "uint256",
+						"name": "minSelfDelegation",
+						"type": "uint256"
+					}
+				],
+				"internalType": "struct Validator[]",
+				"name": "validators",
+				"type": "tuple[]"
+			},
+			{
+				"components": [
+					{
+						"internalType": "bytes",
+						"name": "nextKey",
+						"type": "bytes"
+					},
+					{
+						"internalType": "uint64",
+						"name": "total",
+						"type": "uint64"
+					}
+				],
+				"internalType": "struct PageResponse",
+				"name": "pageResponse",
+				"type": "tuple"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	}
+]

--- a/apps/staking/src/internal/staking/functionality/hooks/useStakingPrecompile.ts
+++ b/apps/staking/src/internal/staking/functionality/hooks/useStakingPrecompile.ts
@@ -1,0 +1,93 @@
+import StakingABI from "../abis/StakingABI.json";
+import { writeContract } from "wagmi/actions";
+import { useSelector } from "react-redux";
+import { StoreType } from "evmos-wallet";
+import { BigNumber } from "@ethersproject/bignumber";
+
+const STAKING_CONTRACT_ADDRESS = "0x0000000000000000000000000000000000000800";
+
+export function useStakingPrecompile() {
+  const address = useSelector((state: StoreType) => state.wallet.value);
+
+  async function delegate(
+    delegatorAddress: string,
+    validatorAddress: string,
+    amount: BigNumber,
+  ) {
+    return await writeContract({
+      mode: "prepared",
+      request: {
+        address: STAKING_CONTRACT_ADDRESS,
+        abi: StakingABI,
+        functionName: "delegate",
+
+        account: address.evmosAddressEthFormat as `0x${string}`,
+        args: [delegatorAddress, validatorAddress, amount],
+      },
+    });
+  }
+
+  async function undelegate(
+    delegatorAddress: string,
+    validatorAddress: string,
+    amount: BigNumber,
+  ) {
+    return await writeContract({
+      mode: "prepared",
+      request: {
+        address: STAKING_CONTRACT_ADDRESS,
+        abi: StakingABI,
+        functionName: "undelegate",
+
+        account: address.evmosAddressEthFormat as `0x${string}`,
+        args: [delegatorAddress, validatorAddress, amount],
+      },
+    });
+  }
+
+  async function redelegate(
+    delegatorAddress: string,
+    validatorSrcAddress: string,
+    validatorDstAddress: string,
+    amount: BigNumber,
+  ) {
+    return await writeContract({
+      mode: "prepared",
+      request: {
+        address: STAKING_CONTRACT_ADDRESS,
+        abi: StakingABI,
+        functionName: "redelegate",
+
+        account: address.evmosAddressEthFormat as `0x${string}`,
+        args: [delegatorAddress, validatorSrcAddress, validatorDstAddress, amount],
+      },
+    });
+  }
+
+  async function cancelUnbondingDelegation(
+    delegatorAddress: string,
+    validatorAddress: string,
+    amount: BigNumber,
+    creationHeight: string
+  ) {
+    return await writeContract({
+      mode: "prepared",
+      request: {
+        address: STAKING_CONTRACT_ADDRESS,
+        abi: StakingABI,
+        functionName: "cancelUnbondingDelegation",
+
+        account: address.evmosAddressEthFormat as `0x${string}`,
+        args: [delegatorAddress, validatorAddress, amount, creationHeight],
+      },
+    });
+  }
+
+
+  return {
+    delegate,
+    undelegate,
+    redelegate,
+    cancelUnbondingDelegation
+  } as const;
+}


### PR DESCRIPTION
# 🧙 Description

This PR migrates the staking app from useing Cosmos Messages to using the new evmos precompiles for:

- delegating
- undelegating
- redelegate
- cancel undelegation
