### PR TITLE
fix: gas estimation wasn't being used on keplr tx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (chore) fse-740 | apps/assets 1.0.31 apps/mission 1.0.24 packages/stateful-components 1.0.1 | Update head component
 - (fix) fse-784 | apps/assets 1.0.30 packages/icons 1.0.7 packages/ui-helpers 1.0.15 | Transaction failure message even if successful
 - (chore) | packages/playwright-config-custom 1.0.3 packages/evmos-wallet 1.0.17 packages/copilot 1.0.6 | Using Lava RPCs as default ones
+- (fix) | packages/evmos-wallet 1.0.18 | Gas estimation wasn't being used in contract calls | Fixes issue with getting the public key for some accounts
 
 ## 1.3.3 - 2023-10-03
 

--- a/packages/evmos-wallet/package.json
+++ b/packages/evmos-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evmos-wallet",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "main": "./src/index.tsx",
   "types": "./src/index.tsx",
   "type": "module",

--- a/packages/evmos-wallet/src/registry-actions/transfers/prepare-contract-erc20-transfer.ts
+++ b/packages/evmos-wallet/src/registry-actions/transfers/prepare-contract-erc20-transfer.ts
@@ -26,11 +26,16 @@ export const prepareContractERC20Transfer = async ({
     args: [normalizeToEth(receiver), token.amount],
     account: normalizeToEth(sender),
   } as const;
-
-  const { request } = await evmosClient.simulateContract(args);
+  const estimatedGas = buffGasEstimate(
+    await evmosClient.estimateContractGas(args)
+  );
+  const { request } = await evmosClient.simulateContract({
+    ...args,
+    gas: estimatedGas,
+  });
   return {
     tx: request,
-    estimatedGas: buffGasEstimate(await evmosClient.estimateContractGas(args)),
+    estimatedGas,
   };
 };
 

--- a/packages/evmos-wallet/src/registry-actions/transfers/prepare-contract-ibc-transfer.ts
+++ b/packages/evmos-wallet/src/registry-actions/transfers/prepare-contract-ibc-transfer.ts
@@ -58,16 +58,22 @@ export const prepareContractIBCTransfer = async <T extends Prefix>({
       "",
     ],
   } as const;
+  const estimatedGas = buffGasEstimate(
+    await evmosClient.estimateContractGas(args)
+  );
 
-  const { request } = await evmosClient.simulateContract(args);
-
+  const { request } = await evmosClient.simulateContract({
+    ...args,
+    gas: estimatedGas,
+  });
   // @ts-expect-error "Safe Wallet" SDK has a bug where this value can't be undefined
   // https://github.com/wagmi-dev/wagmi/issues/2887
   request.value = 0n;
 
+  console.log(request);
   return {
     tx: request,
-    estimatedGas: buffGasEstimate(await evmosClient.estimateContractGas(args)),
+    estimatedGas,
   };
 };
 

--- a/packages/evmos-wallet/src/registry-actions/utils/get-chain-account-info.ts
+++ b/packages/evmos-wallet/src/registry-actions/utils/get-chain-account-info.ts
@@ -13,7 +13,7 @@ type BaseAccount = {
   pub_key: {
     "@type": string;
     key: string;
-  };
+  } | null;
 };
 const isBaseAccount = (account: unknown): account is BaseAccount => {
   return (
@@ -61,18 +61,17 @@ export const getChainAccountInfo = async (address: Address<Prefix>) => {
     throw new Error(`Unsupported account type: ${account["@type"]}`);
   }
 
-  const pubkey =
-    Buffer.from(baseAccount.pub_key.key, "base64") ??
-    (await getPubkey({
-      cosmosChainId: chain.cosmosId,
-    }));
+  const pubkey = baseAccount.pub_key
+    ? Buffer.from(baseAccount.pub_key.key, "base64")
+    : await getPubkey({
+        cosmosChainId: chain.cosmosId,
+      });
 
   return {
     address: cosmosAddress,
     sequence: BigInt(baseAccount.sequence),
     publicKey:
-      baseAccount.pub_key["@type"] ===
-      "/ethermint.crypto.v1.ethsecp256k1.PubKey"
+      chain.identifier === "evmos"
         ? new ethsecp256k1.PubKey({
             key: pubkey,
           })

--- a/packages/evmos-wallet/src/wallet/wagmi/keplrConnector.ts
+++ b/packages/evmos-wallet/src/wallet/wagmi/keplrConnector.ts
@@ -54,7 +54,7 @@ const TransactionRequestSchema = z
 
 const prepareTransaction = async (
   chainId: number,
-  request: TransactionRequest,
+  request: TransactionRequest
 ): Promise<UnsignedTransaction> => {
   const client = getPublicClient({
     chainId,
@@ -305,7 +305,7 @@ export class KeplrConnector extends Connector<Keplr, {}> {
           params[0],
           method === "account_signTransaction"
             ? EthSignType.TRANSACTION
-            : EthSignType.MESSAGE,
+            : EthSignType.MESSAGE
         );
 
         return toHex(signature);
@@ -317,7 +317,7 @@ export class KeplrConnector extends Connector<Keplr, {}> {
           cosmosId,
           bech32Address,
           params[1],
-          EthSignType.EIP712,
+          EthSignType.EIP712
         );
         return toHex(signature);
       }


### PR DESCRIPTION
# 🧙 Description

Two issues actually
we were failing to get the public key for some accounts
also, we were not using the estimations in some contract calls

Ticket #

## ✅ Checklist

- [x] Acceptance Criteria described in the ticket are met
- [ ] Texts and strings are in the related i18n file
- [ ] Utilities have unit tests
- [ ] User stories and functionalities have integration or e2e tests
- [x] Related packages.json are upgraded
- [x] Changelog is updated
