### PR TITLE
chore: release v1.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+## 1.3.4 - 2023-10-17
+
 - (fix) fse-754 | packages/ui-helpers 1.0.16 | Add attribution to Coingecko
 - (fix) fse-778 | apps/assets 1.0.32 packages/helpers 1.0.9 | Update Timestamp for success transactions
 - (chore) fse-740 | apps/assets 1.0.31 apps/mission 1.0.24 packages/stateful-components 1.0.1 | Update head component

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evmos-apps",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "license": "SEE LICENSE IN LICENSE",
   "author": "Tharsis Labs Ltd.(Evmos)",
   "private": true,


### PR DESCRIPTION
# 🧙 Description

Release `v.1.3.4`

- (fix) fse-754 | packages/ui-helpers 1.0.16 | Add attribution to Coingecko
- (fix) fse-778 | apps/assets 1.0.32 packages/helpers 1.0.9 | Update Timestamp for success transactions
- (chore) fse-740 | apps/assets 1.0.31 apps/mission 1.0.24 packages/stateful-components 1.0.1 | Update head component
- (fix) fse-784 | apps/assets 1.0.30 packages/icons 1.0.7 packages/ui-helpers 1.0.15 | Transaction failure message even if successful
- (chore) | packages/playwright-config-custom 1.0.3 packages/evmos-wallet 1.0.17 packages/copilot 1.0.6 | Using Lava RPCs as default ones
- (fix) | packages/evmos-wallet 1.0.18 | Gas estimation wasn't being used in contract calls | Fixes issue with getting the public key for some accounts