### PR TITLE
chore: add evmos 24h price change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+- (chore) fse-754 packages/stateful-components 1.0.2 packages/icons 1.0.8 packages/evmos-wallet 1.0.19
+
 ## 1.3.4 - 2023-10-17
 
 - (fix) fse-754 | packages/ui-helpers 1.0.16 | Add attribution to Coingecko

--- a/packages/evmos-wallet/package.json
+++ b/packages/evmos-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evmos-wallet",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "main": "./src/index.tsx",
   "types": "./src/index.tsx",
   "type": "module",

--- a/packages/evmos-wallet/src/api/types.ts
+++ b/packages/evmos-wallet/src/api/types.ts
@@ -15,6 +15,7 @@ export type ERC20Element = {
   pngSrc: string;
   erc20Address: string;
   tokenIdentifier: string;
+  price24HChange: string;
 };
 
 export type ERC20BalanceResponse = {

--- a/packages/evmos-wallet/src/api/useAssets.ts
+++ b/packages/evmos-wallet/src/api/useAssets.ts
@@ -84,6 +84,14 @@ export const useAssets = () => {
     return assets.data.balance[0].coingeckoPrice;
   }, [assets.data]);
 
+  const getEvmosPriceChange = useMemo(() => {
+    if (assets.data === undefined || assets.data.balance.length === 0) {
+      return "--";
+    }
+
+    return assets.data.balance[0].price24HChange;
+  }, [assets.data]);
+
   const getTotalEvmos = useMemo(() => {
     // returns the amount of evmos and wrap evmos
     let total = BigNumber.from(0);
@@ -116,6 +124,7 @@ export const useAssets = () => {
     totalAssets: getTotalAssetsForMissionControl,
     totalEvmosAsset: getTotalEvmos,
     evmosPrice: getEvmosPrice,
+    evmosPriceChange: getEvmosPriceChange,
     evmosPriceFixed,
     loading: assets.isLoading,
     error: assets.error,

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "icons",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "main": "./src/index.tsx",
   "types": "./src/index.tsx",
   "type": "module",

--- a/packages/icons/src/PriceDown.tsx
+++ b/packages/icons/src/PriceDown.tsx
@@ -1,0 +1,21 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
+
+type PriceDownIconProps = React.SVGAttributes<SVGElement> & {
+  color?: string;
+};
+
+export const PriceDown: React.FC<PriceDownIconProps> = ({
+  width = "16",
+  height = "16",
+  ...restProps
+}) => {
+  return (
+    <svg {...restProps} width={width} height={height} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M1 6.25L8 13.25L10.625 10.625L15 15" stroke="#ED4E33" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" />
+      <path d="M11.5 1V8M11.5 8L14.125 5.375M11.5 8L8.875 5.375" stroke="#ED4E33" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" />
+    </svg>
+
+  );
+};
+

--- a/packages/icons/src/PriceUp.tsx
+++ b/packages/icons/src/PriceUp.tsx
@@ -1,0 +1,20 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
+
+type PriceUpIconProps = React.SVGAttributes<SVGElement> & {
+  color?: string;
+};
+
+export const PriceUp: React.FC<PriceUpIconProps> = ({
+  width = "16",
+  height = "16",
+  ...restProps
+}) => {
+  return (
+    <svg {...restProps} width={width} height={height} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M10.8149 14.0859V7.54297M10.8149 7.54297L13.2686 9.99658M10.8149 7.54297L8.36133 9.99658" stroke="#31B886" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" />
+      <path d="M1 9.17871L7.54297 2.63574L9.99658 5.08936L14.0859 1" stroke="#31B886" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" />
+    </svg>
+  );
+};
+

--- a/packages/icons/src/index.tsx
+++ b/packages/icons/src/index.tsx
@@ -61,3 +61,5 @@ export { ReceiveIcon } from "./ReceiveIcon";
 export { PayIcon } from "./PayIcon";
 export { ShareIcon } from "./ShareIcon";
 export { ProcessingTxIcon } from "./ProcessingTxIcon";
+export {PriceDown} from "./PriceDown"
+export {PriceUp} from "./PriceUp"

--- a/packages/stateful-components/package.json
+++ b/packages/stateful-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stateful-components",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "./src/index.tsx",
   "types": "./src/index.tsx",
   "type": "module",

--- a/packages/stateful-components/src/StatefulHeader.tsx
+++ b/packages/stateful-components/src/StatefulHeader.tsx
@@ -24,7 +24,7 @@ export const StatefulHeader = ({
   const dispatch = useDispatch();
 
   const { handlePreClickAction } = useTracker(CLICK_EVMOS_LOGO);
-  const { evmosPriceFixed } = useAssets();
+  const { evmosPriceFixed, evmosPriceChange } = useAssets();
 
   const launchPad = {
     dApps: launchPadItems,
@@ -59,6 +59,7 @@ export const StatefulHeader = ({
                 page: page,
               });
             }}
+            evmosPriceChange={parseFloat(evmosPriceChange)}
             price={evmosPriceFixed}
           />
         </TranslationContextProvider>

--- a/packages/ui-helpers/src/Header.tsx
+++ b/packages/ui-helpers/src/Header.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
 
 import Link from "next/link";
-import { EvmosRedIcon, Logo } from "icons";
+import { EvmosRedIcon, Logo, PriceDown, PriceUp } from "icons";
 import { EVMOS_PAGE_URL } from "constants-helper";
 import { LaunchContainer } from "./launchPad/Container";
 import { LaunchPadProps } from "./launchPad/types";
@@ -13,13 +13,16 @@ export const Header = ({
   price,
   pageName,
   launchPad,
+  evmosPriceChange
 }: {
   walletConnectionButton?: JSX.Element;
   onClick?: React.MouseEventHandler<HTMLAnchorElement>;
   price?: string;
   pageName: string;
   launchPad: LaunchPadProps;
+  evmosPriceChange: number;
 }) => {
+
   return (
     <div className="mt-5 md:mt-0 text-pearl mb-3 flex flex-col md:mx-0 md:h-32 md:flex-row md:items-center md:justify-between">
       <Link
@@ -38,6 +41,11 @@ export const Header = ({
         <div className="font-sm text-pearl bg-darGray800 hidden cursor-default items-center justify-center space-x-3 rounded-full px-4 py-2 font-bold md:flex">
           <EvmosRedIcon width={"20"} height={"20"} />
           <span>{price}</span>
+
+          <div className="flex items-center gap-1">
+            {evmosPriceChange > 0 ? <PriceUp /> : <PriceDown />}
+            <span className={`${evmosPriceChange > 0 ? "text-[#31B886]" : "text-[#ED4E33]"} font-normal`}>{evmosPriceChange.toFixed(2)}%</span>
+          </div>
         </div>
         <div className="flex items-center space-x-3">
           <LaunchContainer launchPad={launchPad} />


### PR DESCRIPTION
# 🧙 Description

This PR adds EVMOS price 24h percentage change banner and icon to the price component in the header
