### PR TITLE
redirect to assets app on staging

### DIFF
--- a/apps/mission/public/_redirects_staging
+++ b/apps/mission/public/_redirects_staging
@@ -1,4 +1,4 @@
 /portfolio/* https://evmos-assets.netlify.app/portfolio/:splat 200!
 /staking/* https://evmos-staking.netlify.app/staking/:splat 200!
 /governance/* https://evmos-governance.netlify.app/governance/:splat 200!
-/assets/* /portfolio/:splat 200!
+/assets/* https://staging-app.evmos.org/portfolio/:splat


### PR DESCRIPTION
# 🧙 Description

Trying  `/assets/* https://staging-app.evmos.org/portfolio/:splat` instead of /portfolio

Ticket #fse-794

## ✅ Checklist

- [ ] Acceptance Criteria described in the ticket are met
- [ ] Texts and strings are in the related i18n file
- [ ] Utilities have unit tests
- [ ] User stories and functionalities have integration or e2e tests
- [ ] Related packages.json are upgraded
- [ ] Changelog is updated
