### PR TITLE
fix: update dappwright and some e2e tests

### DIFF
--- a/apps/mission/e2e/copilot.nonetwork.spec.ts
+++ b/apps/mission/e2e/copilot.nonetwork.spec.ts
@@ -1,5 +1,6 @@
 import { noNetworkMMFixture, waitLocator } from "@evmosapps/test-utils";
 import { BALANCE_ENDPOINT } from "./constants";
+import { pageListener } from "@evmosapps/test-utils";
 
 const { test, beforeEach, describe, expect, step } = noNetworkMMFixture;
 
@@ -26,6 +27,7 @@ describe("Mission Page - Copilot", () => {
 
   test("should let the user connect with MetaMask, set the network, the accounts, top up the account and redirect to the ecosystem page", async ({
     page,
+    context,
   }) => {
     await step("Reject Connect", async () => {
       await page.getByRole("button", { name: /Connect/i }).click();
@@ -35,17 +37,20 @@ describe("Mission Page - Copilot", () => {
           name: /Evmos Copilot Recommended for first time users New/i,
         })
         .click();
-
+      const switchNetworkPopup = pageListener(context);
       await page
         .getByRole("button", {
           name: /Connect with MetaMask/i,
         })
         .click();
-      const switchNetworkPopup = await page.context().waitForEvent("page");
+
+      await switchNetworkPopup.load;
 
       await expect(page.getByText(/Approve on MetaMask/i)).toBeVisible();
 
-      await switchNetworkPopup.getByRole("button", { name: /Cancel/i }).click();
+      await switchNetworkPopup.page
+        .getByRole("button", { name: /Cancel/i })
+        .click();
 
       await expect(
         page.getByText(/Approval Rejected, please try again/i)
@@ -53,22 +58,24 @@ describe("Mission Page - Copilot", () => {
     });
 
     await step("Reject switch network", async () => {
+      const switchNetworkPopupRetry = pageListener(context);
       await page
         .getByRole("button", {
           name: /Try again/i,
         })
         .click();
-      const switchNetworkPopupRetry = await page.context().waitForEvent("page");
-      await switchNetworkPopupRetry
+      await switchNetworkPopupRetry.load;
+
+      await switchNetworkPopupRetry.page
         .getByRole("button", { name: /Approve/i })
         .click();
 
-      await switchNetworkPopupRetry
+      await switchNetworkPopupRetry.page
         .getByRole("heading", {
           name: "Allow this site to switch the network?",
         })
         .waitFor();
-      await switchNetworkPopupRetry
+      await switchNetworkPopupRetry.page
         .getByRole("button", { name: /Cancel/i })
         .click();
 
@@ -80,24 +87,27 @@ describe("Mission Page - Copilot", () => {
     });
 
     await step("Reject get accounts", async () => {
+      const switchNetworkPopupRetryAfterApprove = pageListener(context);
       await page
         .getByRole("button", {
           name: /Try again/i,
         })
         .click();
+      await switchNetworkPopupRetryAfterApprove.load;
 
-      const switchNetworkPopupRetryAfterApprove = await page
-        .context()
-        .waitForEvent("page");
-
-      await switchNetworkPopupRetryAfterApprove
+      await switchNetworkPopupRetryAfterApprove.page
         .getByRole("button", { name: /Switch Network/i })
         .click();
 
+      const getAccountsPopup = pageListener(context);
+
       await expect(page.getByText(/Press Next and Connect/i)).toBeVisible();
 
-      const getAccountsPopup = await page.context().waitForEvent("page");
-      await getAccountsPopup.getByRole("button", { name: /Cancel/i }).click();
+      await getAccountsPopup.load;
+
+      await getAccountsPopup.page
+        .getByRole("button", { name: /Cancel/i })
+        .click();
 
       await expect(
         page.getByText(/Get accounts rejected, please try again/i)
@@ -105,17 +115,21 @@ describe("Mission Page - Copilot", () => {
     });
 
     await step("Approve Pubkey", async () => {
+      const approveAllPopup = pageListener(context);
+
       await page
         .getByRole("button", {
           name: /Try again/i,
         })
         .click();
 
-      const approveAllPopup = await page.context().waitForEvent("page");
+      await approveAllPopup.load;
 
-      await approveAllPopup.getByRole("button", { name: /Next/i }).click();
-      await approveAllPopup.getByRole("button", { name: /Connect/i }).click();
-      await approveAllPopup.getByRole("button", { name: /Sign/i }).click();
+      await approveAllPopup.page.getByRole("button", { name: /Next/i }).click();
+      await approveAllPopup.page
+        .getByRole("button", { name: /Connect/i })
+        .click();
+      await approveAllPopup.page.getByRole("button", { name: /Sign/i }).click();
     });
 
     await step("Top up account", async () => {

--- a/apps/mission/e2e/copilot.nonetwork.spec.ts
+++ b/apps/mission/e2e/copilot.nonetwork.spec.ts
@@ -64,6 +64,11 @@ describe("Mission Page - Copilot", () => {
         .click();
 
       await switchNetworkPopupRetry
+        .getByRole("heading", {
+          name: "Allow this site to switch the network?",
+        })
+        .waitFor();
+      await switchNetworkPopupRetry
         .getByRole("button", { name: /Cancel/i })
         .click();
 

--- a/apps/mission/e2e/copilot.spec.ts
+++ b/apps/mission/e2e/copilot.spec.ts
@@ -1,5 +1,6 @@
 import { mmFixture } from "@evmosapps/test-utils";
 import { BALANCE_ENDPOINT } from "./constants";
+import { pageListener } from "@evmosapps/test-utils";
 
 const { test, beforeEach, describe, expect } = mmFixture;
 
@@ -39,12 +40,15 @@ describe("Mission Page - Copilot", () => {
       })
       .click();
 
+    const approveAllPopup = pageListener(page.context());
     await expect(page.getByText(/Press Next and Connect/i)).toBeVisible();
-    const approveAllPopup = await page.context().waitForEvent("page");
+    await approveAllPopup.load;
 
-    await approveAllPopup.getByRole("button", { name: /Next/i }).click();
-    await approveAllPopup.getByRole("button", { name: /Connect/i }).click();
-    await approveAllPopup.getByRole("button", { name: /Sign/i }).click();
+    await approveAllPopup.page.getByRole("button", { name: /Next/i }).click();
+    await approveAllPopup.page
+      .getByRole("button", { name: /Connect/i })
+      .click();
+    await approveAllPopup.page.getByRole("button", { name: /Sign/i }).click();
 
     await page.getByRole("button", { name: /Top up your account/i }).click();
     await page.route(`${BALANCE_ENDPOINT}`, async (route) => {

--- a/apps/mission/e2e/copilot.spec.ts
+++ b/apps/mission/e2e/copilot.spec.ts
@@ -85,18 +85,18 @@ describe("Mission Page - Copilot", () => {
 
     await page.getByRole("button", { name: "Cryptocurrencies" }).click();
 
-    const lawerSwapWidget = page.getByTestId("layerswap-widget");
-    await lawerSwapWidget.waitFor();
-
-    expect(await lawerSwapWidget.count()).toBe(1);
-
-    await page.getByTestId("card-provider-dropdown").click();
-    await page.getByRole("button", { name: /Squid/i }).click();
-
     const squidDWidget = page.getByTestId("squid-widget");
     await squidDWidget.waitFor();
 
     expect(await squidDWidget.count()).toBe(1);
+
+    await page.getByTestId("card-provider-dropdown").click();
+    await page.getByRole("button", { name: /LayerSwap/i }).click();
+
+    const lawerSwapWidget = page.getByTestId("layerswap-widget");
+    await lawerSwapWidget.waitFor();
+
+    expect(await lawerSwapWidget.count()).toBe(1);
 
     await page.getByTestId("card-provider-dropdown").click();
     await page.getByRole("button", { name: /Cypher Wallet/i }).click();

--- a/apps/mission/e2e/dappstore.spec.ts
+++ b/apps/mission/e2e/dappstore.spec.ts
@@ -1,4 +1,4 @@
-import { mmFixture } from "@evmosapps/test-utils";
+import { mmFixture, pageListener } from "@evmosapps/test-utils";
 import {
   STAKING_INFO_ENDPOINT,
   responseEmptyInfoStaking,
@@ -260,20 +260,26 @@ describe("Mission Page - Copilot", () => {
     await page.waitForTimeout(3000);
 
     await page.getByRole("button", { name: /Connect/i }).click();
+    const approveAllPopup = pageListener(page.context());
+
     await page.getByRole("button", { name: /MetaMask/i }).click();
-    const approveAllPopup = await page.context().waitForEvent("page");
+    await approveAllPopup.load;
 
-    await approveAllPopup.getByRole("button", { name: /Next/i }).click();
-    await approveAllPopup.getByRole("button", { name: /Connect/i }).click();
-    await approveAllPopup.getByRole("button", { name: /Sign/i }).click();
-
+    await approveAllPopup.page.getByRole("button", { name: /Next/i }).click();
+    await approveAllPopup.page
+      .getByRole("button", { name: /Connect/i })
+      .click();
+    await approveAllPopup.page.getByRole("button", { name: /Sign/i }).click();
+    const switchNetworkPopup = pageListener(page.context());
     await page
       .getByRole("button", {
         name: /Claim Rewards/i,
       })
       .click();
+    await switchNetworkPopup.load;
 
-    const switchNetworkPopup = await page.context().waitForEvent("page");
-    await switchNetworkPopup.getByRole("button", { name: /Reject/i }).click();
+    await switchNetworkPopup.page
+      .getByRole("button", { name: /Reject/i })
+      .click();
   });
 });

--- a/packages/copilot/src/copilot/steps/topUp/Squid.tsx
+++ b/packages/copilot/src/copilot/steps/topUp/Squid.tsx
@@ -54,7 +54,10 @@ const encodedConfig = encodeURIComponent(configJSON); // Encode the JSON string
 
 export const Squid = () => {
   return (
-    <div className="relative mx-auto mt-[25px] h-[700px] w-[300px] overflow-hidden rounded-[15px] md:h-[690px] md:w-[400px]">
+    <div
+      className="relative mx-auto mt-[25px] h-[700px] w-[300px] overflow-hidden rounded-[15px] md:h-[690px] md:w-[400px]"
+      data-testid="squid-widget"
+    >
       <iframe
         title="squid-widget"
         width="100%"

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "devDependencies": {
     "@playwright/test": "^1.39.0",
-    "@tenkeylabs/dappwright": "^2.4.0",
+    "@tenkeylabs/dappwright": "^2.5.2",
     "octokit": "^3.1.1",
     "tsx": "^3.13.0"
   },

--- a/packages/test-utils/playwright/fixtures/metamask.ts
+++ b/packages/test-utils/playwright/fixtures/metamask.ts
@@ -1,8 +1,9 @@
 import { BrowserContext, test } from "@playwright/test";
-import dappwright, { Dappwright } from "@tenkeylabs/dappwright";
+import dappwright, { Dappwright, MetaMaskWallet } from "@tenkeylabs/dappwright";
 import os from "os";
 import path from "path";
 import { rm } from "fs/promises";
+
 const E2E_TEST_EVMOS_CHAIN_NAME =
   process.env.E2E_TEST_EVMOS_CHAIN_NAME ?? "Evmos";
 const E2E_TEST_EVMOS_RPC_URL =
@@ -11,7 +12,6 @@ const E2E_TEST_EVMOS_CHAIN_ID = parseInt(
   process.env.E2E_TEST_EVMOS_CHAIN_ID ?? "9001"
 );
 const E2E_TEST_EVMOS_SYMBOL = process.env.E2E_TEST_EVMOS_SYMBOL ?? "EVMOS";
-const mmVersion = "10.26.2";
 
 const clearDappwright = async () => {
   try {
@@ -28,7 +28,7 @@ export const web3Test = test.extend<{
     await clearDappwright();
     const [wallet, , context] = await dappwright.bootstrap("", {
       wallet: "metamask",
-      version: mmVersion,
+      version: MetaMaskWallet.recommendedVersion,
       seed:
         process.env.E2E_TEST_SEED ??
         "test test test test test test test test test test test junk",
@@ -60,7 +60,7 @@ export const web3TestWithoutNetwork = test.extend<{
     await clearDappwright();
     const [, , context] = await dappwright.bootstrap("", {
       wallet: "metamask",
-      version: mmVersion,
+      version: MetaMaskWallet.recommendedVersion,
 
       seed:
         process.env.E2E_TEST_SEED ??

--- a/packages/test-utils/playwright/utils/index.ts
+++ b/packages/test-utils/playwright/utils/index.ts
@@ -1,3 +1,4 @@
 export * from "./wait-locator";
 export * from "./flow";
 export * from "./keplr";
+export * from "./page-listener";

--- a/packages/test-utils/playwright/utils/page-listener.ts
+++ b/packages/test-utils/playwright/utils/page-listener.ts
@@ -1,5 +1,36 @@
 import { BrowserContext, Page } from "@playwright/test";
 
+/**
+ * Creates a listener for a new page in a given browser context.
+ *
+ * This is to facilitate the pattern of listening for a new page before actually triggering it
+ * (e.g. clicking a button that opens a new page).
+ * @example
+ * ```ts
+ * const popup = pageListener(context); // setup page listener
+ * await currentPage.getByText('open new page').click(); // trigger new page
+ * 
+ * await popup.load; // wait for new page to load. Always await for this AFTER triggering the new page event, but BEFORE doing anything with the new page
+ * 
+ * await popup.page.getByText('new page') // do something with new page
+ * ```
+ * 
+ * You don't need to use this helper though, but if you don't, make sure you setup the listener BEFORE triggering the new page event
+ * ```ts
+ * // ✅ DO THIS:
+ * const newPagePromise = context.waitForEvent('page');
+ * await currentPage.getByText('open new page').click();
+ * const newPage = await newPagePromise;
+
+ * //⛔ NOT THIS:
+ * await page.getByText('open new page').click();
+ * const newPage = await context.waitForEvent('page'); // <- by the point you set this listener, the event might already have been fired
+ * ```
+ * @param context - The browser context to listen for new pages.
+ * @returns An object with a `load` property that resolves when a new page is created,
+ * and a `page` property that returns the newly created page.
+ * @throws An error if the page has not been loaded yet.
+ */
 export const pageListener = (context: BrowserContext) => {
   const promise = context.waitForEvent("page");
   let page: Page | null = null;

--- a/packages/test-utils/playwright/utils/page-listener.ts
+++ b/packages/test-utils/playwright/utils/page-listener.ts
@@ -1,0 +1,17 @@
+import { BrowserContext, Page } from "@playwright/test";
+
+export const pageListener = (context: BrowserContext) => {
+  const promise = context.waitForEvent("page");
+  let page: Page | null = null;
+
+  void promise.then((p) => {
+    page = p;
+  });
+  return {
+    load: promise,
+    get page() {
+      if (!page) throw new Error("Page not loaded");
+      return page;
+    },
+  };
+};

--- a/packages/testnet/package.json
+++ b/packages/testnet/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "@evmosapps/config": "workspace:*",
     "@playwright/test": "^1.39.0",
-    "@tenkeylabs/dappwright": "^2.4.0",
+    "@tenkeylabs/dappwright": "^2.5.2",
     "@types/inquirer": "^9.0.4",
     "octokit": "^3.1.1",
     "tsx": "^3.13.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1492,8 +1492,8 @@ importers:
         specifier: ^1.39.0
         version: 1.39.0
       '@tenkeylabs/dappwright':
-        specifier: ^2.4.0
-        version: 2.4.0(playwright-core@1.39.0)
+        specifier: ^2.5.2
+        version: 2.5.2(playwright-core@1.39.0)
       octokit:
         specifier: ^3.1.1
         version: 3.1.1
@@ -1574,7 +1574,7 @@ importers:
         version: 1.0.34
       ws:
         specifier: ^8.14.2
-        version: 8.14.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        version: 8.14.2
     devDependencies:
       '@evmosapps/config':
         specifier: workspace:*
@@ -1583,8 +1583,8 @@ importers:
         specifier: ^1.39.0
         version: 1.39.0
       '@tenkeylabs/dappwright':
-        specifier: ^2.4.0
-        version: 2.4.0(playwright-core@1.39.0)
+        specifier: ^2.5.2
+        version: 2.5.2(playwright-core@1.39.0)
       '@types/inquirer':
         specifier: ^9.0.4
         version: 9.0.4
@@ -5361,8 +5361,8 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: true
 
-  /@tenkeylabs/dappwright@2.4.0(playwright-core@1.39.0):
-    resolution: {integrity: sha512-6Y62KnqcWx6QvgMDpIcwtTbg+1AWtq+ZWTHd5Pgq0E5kjP4UPZnbhIqtYyEUT5WH+h9RNkNo8Zs3Av1liYRuyg==}
+  /@tenkeylabs/dappwright@2.5.2(playwright-core@1.39.0):
+    resolution: {integrity: sha512-90bYZxYDBKadsl783zqp6Sa+Kj4RJHK4RydDcaVjik5WD3xLwXgl0J/9ktCPXBvWHh/68ExvP4EadxOvdhfVag==}
     engines: {node: '>=16'}
     peerDependencies:
       playwright-core: '>1.0'
@@ -14845,6 +14845,19 @@ packages:
       utf-8-validate:
         optional: true
     dev: true
+
+  /ws@8.14.2:
+    resolution: {integrity: sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+    dev: false
 
   /ws@8.14.2(bufferutil@4.0.8)(utf-8-validate@5.0.10):
     resolution: {integrity: sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,13 +37,13 @@ importers:
         version: 7.2.1
       eslint:
         specifier: ^8.47.0
-        version: 8.47.0
+        version: 8.52.0
       eslint-interactive:
         specifier: ^10.8.0
-        version: 10.8.0(eslint@8.47.0)
+        version: 10.8.0(eslint@8.52.0)
       eslint-nibble:
         specifier: ^8.1.0
-        version: 8.1.0(eslint@8.47.0)
+        version: 8.1.0(eslint@8.52.0)
       helpers:
         specifier: workspace:*
         version: link:packages/helpers
@@ -137,10 +137,10 @@ importers:
         version: 1.9.5(react-redux@8.1.2)(react@18.2.0)
       '@tanstack/react-query':
         specifier: ^4.32.6
-        version: 4.32.6(react-dom@18.2.0)(react@18.2.0)
+        version: 4.36.1(react-dom@18.2.0)(react@18.2.0)
       '@tanstack/react-query-devtools':
         specifier: ^4.35.0
-        version: 4.35.0(@tanstack/react-query@4.32.6)(react-dom@18.2.0)(react@18.2.0)
+        version: 4.35.0(@tanstack/react-query@4.36.1)(react-dom@18.2.0)(react@18.2.0)
       '@testing-library/react':
         specifier: ^14.0.0
         version: 14.0.0(react-dom@18.2.0)(react@18.2.0)
@@ -155,7 +155,7 @@ importers:
         version: 2.47.1
       chainapsis-suggest-chain:
         specifier: github:chainapsis/keplr-chain-registry
-        version: github.com/chainapsis/keplr-chain-registry/2fe91c451ac09b86857d1ce5d60012232cedf4e6(@babel/core@7.23.2)(react-is@18.2.0)
+        version: github.com/chainapsis/keplr-chain-registry/7e580771af32f95c41f49b3596ce9da2a56b350a(@babel/core@7.23.2)(react-is@18.2.0)
       dotenv:
         specifier: ^16.3.1
         version: 16.3.1
@@ -183,7 +183,7 @@ importers:
         version: 5.7.0
       '@evmos/proto':
         specifier: ^0.1.26
-        version: 0.1.26
+        version: 0.1.27
       '@evmos/provider':
         specifier: ^0.2.8
         version: 0.2.8
@@ -204,7 +204,7 @@ importers:
         version: 1.0.1
       '@keplr-wallet/types':
         specifier: ^0.12.20
-        version: 0.12.20
+        version: 0.12.34
       '@types/node':
         specifier: 20.4.1
         version: 20.4.1
@@ -234,7 +234,7 @@ importers:
         version: link:../../packages/helpers
       i18next:
         specifier: ^23.4.4
-        version: 23.4.4
+        version: 23.6.0
       icons:
         specifier: workspace:*
         version: link:../../packages/icons
@@ -243,7 +243,7 @@ importers:
         version: 13.5.5(@babel/core@7.23.2)(react-dom@18.2.0)(react@18.2.0)
       next-i18next:
         specifier: ^14.0.0
-        version: 14.0.0(i18next@23.4.4)(next@13.5.5)(react-i18next@13.1.0)(react@18.2.0)
+        version: 14.0.0(i18next@23.6.0)(next@13.5.5)(react-i18next@13.3.1)(react@18.2.0)
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -252,7 +252,7 @@ importers:
         version: 18.2.0(react@18.2.0)
       react-i18next:
         specifier: ^13.1.0
-        version: 13.1.0(i18next@23.4.4)(react-dom@18.2.0)(react@18.2.0)
+        version: 13.3.1(i18next@23.6.0)(react-dom@18.2.0)(react@18.2.0)
       react-redux:
         specifier: ^8.1.2
         version: 8.1.2(@types/react-dom@18.0.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(redux@4.2.1)
@@ -289,7 +289,7 @@ importers:
         version: 5.7.0
       '@evmos/proto':
         specifier: ^0.1.26
-        version: 0.1.26
+        version: 0.1.27
       '@evmos/provider':
         specifier: ^0.2.8
         version: 0.2.8
@@ -307,7 +307,7 @@ importers:
         version: 1.0.1
       '@keplr-wallet/types':
         specifier: ^0.12.20
-        version: 0.12.20
+        version: 0.12.34
       '@metamask/providers':
         specifier: ^10.2.1
         version: 10.2.1
@@ -316,7 +316,7 @@ importers:
         version: 1.9.5(react-redux@8.1.2)(react@18.2.0)
       '@tanstack/react-query':
         specifier: ^4.32.6
-        version: 4.32.6(react-dom@18.2.0)(react@18.2.0)
+        version: 4.36.1(react-dom@18.2.0)(react@18.2.0)
       '@types/node':
         specifier: 20.4.1
         version: 20.4.1
@@ -328,7 +328,7 @@ importers:
         version: 18.0.9
       autoprefixer:
         specifier: ^10.4.13
-        version: 10.4.13(postcss@8.4.20)
+        version: 10.4.13(postcss@8.4.31)
       constants-helper:
         specifier: workspace:*
         version: link:../../packages/constants-helper
@@ -352,7 +352,7 @@ importers:
         version: 13.5.5(@babel/core@7.23.2)(react-dom@18.2.0)(react@18.2.0)
       postcss:
         specifier: ^8.4.20
-        version: 8.4.20
+        version: 8.4.31
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -382,7 +382,7 @@ importers:
         version: link:../../packages/tailwind-config
       tailwindcss:
         specifier: ^3.3.3
-        version: 3.3.3
+        version: 3.3.4
       tracker:
         specifier: workspace:*
         version: link:../../packages/tracker
@@ -400,10 +400,10 @@ importers:
         version: 1.39.0
       '@tanstack/query-sync-storage-persister':
         specifier: ^4.32.6
-        version: 4.32.6
+        version: 4.36.1
       '@tanstack/react-query-persist-client':
         specifier: ^4.32.6
-        version: 4.32.6(@tanstack/react-query@4.32.6)
+        version: 4.36.1(@tanstack/react-query@4.36.1)
       '@testing-library/react':
         specifier: ^14.0.0
         version: 14.0.0(react-dom@18.2.0)(react@18.2.0)
@@ -422,7 +422,7 @@ importers:
         version: 5.7.0
       '@evmos/proto':
         specifier: ^0.1.26
-        version: 0.1.26
+        version: 0.1.27
       '@evmos/provider':
         specifier: ^0.2.8
         version: 0.2.8
@@ -440,7 +440,7 @@ importers:
         version: 1.0.1
       '@keplr-wallet/types':
         specifier: ^0.12.20
-        version: 0.12.20
+        version: 0.12.34
       '@metamask/providers':
         specifier: ^10.2.1
         version: 10.2.1
@@ -449,7 +449,7 @@ importers:
         version: 1.9.5(react-redux@8.1.2)(react@18.2.0)
       '@tanstack/react-query':
         specifier: ^4.32.6
-        version: 4.32.6(react-dom@18.2.0)(react@18.2.0)
+        version: 4.36.1(react-dom@18.2.0)(react@18.2.0)
       '@types/node':
         specifier: 20.4.1
         version: 20.4.1
@@ -461,7 +461,7 @@ importers:
         version: 18.0.9
       autoprefixer:
         specifier: ^10.4.13
-        version: 10.4.13(postcss@8.4.20)
+        version: 10.4.13(postcss@8.4.31)
       constants-helper:
         specifier: workspace:*
         version: link:../../packages/constants-helper
@@ -479,7 +479,7 @@ importers:
         version: link:../../packages/helpers
       i18next:
         specifier: ^23.4.4
-        version: 23.4.4
+        version: 23.6.0
       icons:
         specifier: workspace:*
         version: link:../../packages/icons
@@ -488,10 +488,10 @@ importers:
         version: 13.5.5(@babel/core@7.23.2)(react-dom@18.2.0)(react@18.2.0)
       next-i18next:
         specifier: ^14.0.0
-        version: 14.0.0(i18next@23.4.4)(next@13.5.5)(react-i18next@13.1.0)(react@18.2.0)
+        version: 14.0.0(i18next@23.6.0)(next@13.5.5)(react-i18next@13.3.1)(react@18.2.0)
       postcss:
         specifier: ^8.4.20
-        version: 8.4.20
+        version: 8.4.31
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -500,7 +500,7 @@ importers:
         version: 18.2.0(react@18.2.0)
       react-i18next:
         specifier: ^13.1.0
-        version: 13.1.0(i18next@23.4.4)(react-dom@18.2.0)(react@18.2.0)
+        version: 13.3.1(i18next@23.6.0)(react-dom@18.2.0)(react@18.2.0)
       react-markdown:
         specifier: ^8.0.5
         version: 8.0.5(@types/react@18.2.21)(react@18.2.0)
@@ -524,7 +524,7 @@ importers:
         version: link:../../packages/tailwind-config
       tailwindcss:
         specifier: ^3.3.3
-        version: 3.3.3
+        version: 3.3.4
       tracker:
         specifier: workspace:*
         version: link:../../packages/tracker
@@ -567,7 +567,7 @@ importers:
         version: 5.7.0
       '@evmos/proto':
         specifier: ^0.1.26
-        version: 0.1.26
+        version: 0.1.27
       '@evmos/provider':
         specifier: ^0.2.8
         version: 0.2.8
@@ -585,7 +585,7 @@ importers:
         version: 1.0.1
       '@keplr-wallet/types':
         specifier: ^0.12.20
-        version: 0.12.20
+        version: 0.12.34
       '@metamask/providers':
         specifier: ^10.2.1
         version: 10.2.1
@@ -597,7 +597,7 @@ importers:
         version: 1.9.5(react-redux@8.1.2)(react@18.2.0)
       '@tanstack/react-query':
         specifier: ^4.32.6
-        version: 4.32.6(react-dom@18.2.0)(react@18.2.0)
+        version: 4.36.1(react-dom@18.2.0)(react@18.2.0)
       '@types/node':
         specifier: 20.4.1
         version: 20.4.1
@@ -609,7 +609,7 @@ importers:
         version: 18.0.9
       autoprefixer:
         specifier: ^10.4.13
-        version: 10.4.13(postcss@8.4.20)
+        version: 10.4.13(postcss@8.4.31)
       dotenv:
         specifier: ^16.3.1
         version: 16.3.1
@@ -624,7 +624,7 @@ importers:
         version: 13.5.5(@babel/core@7.23.2)(react-dom@18.2.0)(react@18.2.0)
       postcss:
         specifier: ^8.4.20
-        version: 8.4.20
+        version: 8.4.31
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -651,7 +651,7 @@ importers:
         version: link:../../packages/tailwind-config
       tailwindcss:
         specifier: ^3.3.3
-        version: 3.3.3
+        version: 3.3.4
       tracker:
         specifier: workspace:*
         version: link:../../packages/tracker
@@ -715,7 +715,7 @@ importers:
         version: 5.7.2
       '@evmos/proto':
         specifier: ^0.1.26
-        version: 0.1.26
+        version: 0.1.27
       '@evmos/provider':
         specifier: ^0.2.8
         version: 0.2.8
@@ -733,7 +733,7 @@ importers:
         version: 1.0.1
       '@keplr-wallet/types':
         specifier: ^0.12.20
-        version: 0.12.20
+        version: 0.12.34
       '@metamask/providers':
         specifier: ^10.2.1
         version: 10.2.1
@@ -742,7 +742,7 @@ importers:
         version: 1.9.5(react-redux@8.1.2)(react@18.2.0)
       '@tanstack/react-query':
         specifier: ^4.32.6
-        version: 4.32.6(react-dom@18.2.0)(react@18.2.0)
+        version: 4.36.1(react-dom@18.2.0)(react@18.2.0)
       '@types/node':
         specifier: 20.4.1
         version: 20.4.1
@@ -754,7 +754,7 @@ importers:
         version: 18.0.9
       autoprefixer:
         specifier: ^10.4.13
-        version: 10.4.13(postcss@8.4.20)
+        version: 10.4.13(postcss@8.4.31)
       ethers:
         specifier: ^6.7.1
         version: 6.7.1
@@ -766,7 +766,7 @@ importers:
         version: 14.0.0(i18next@23.6.0)(next@13.5.5)(react-i18next@13.3.1)(react@18.2.0)
       postcss:
         specifier: ^8.4.20
-        version: 8.4.20
+        version: 8.4.31
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -793,7 +793,7 @@ importers:
         version: link:../../packages/tailwind-config
       tailwindcss:
         specifier: ^3.3.3
-        version: 3.3.3
+        version: 3.3.4
       typescript:
         specifier: ^5.2.2
         version: 5.2.2
@@ -802,22 +802,22 @@ importers:
     dependencies:
       '@babel/cli':
         specifier: ^7.22.10
-        version: 7.22.10(@babel/core@7.22.10)
+        version: 7.22.10(@babel/core@7.23.2)
       '@babel/core':
         specifier: ^7.22.10
-        version: 7.22.10
+        version: 7.23.2
       '@babel/eslint-parser':
         specifier: ^7.22.10
-        version: 7.22.10(@babel/core@7.22.10)(eslint@8.47.0)
+        version: 7.22.10(@babel/core@7.23.2)(eslint@8.52.0)
       '@babel/plugin-syntax-import-assertions':
         specifier: ^7.22.5
-        version: 7.22.5(@babel/core@7.22.10)
+        version: 7.22.5(@babel/core@7.23.2)
       '@babel/preset-env':
         specifier: ^7.22.10
-        version: 7.22.10(@babel/core@7.22.10)
+        version: 7.22.10(@babel/core@7.23.2)
       '@eslint/eslintrc':
         specifier: ^2.1.1
-        version: 2.1.1
+        version: 2.1.2
       '@next/bundle-analyzer':
         specifier: ^13.4.17
         version: 13.4.17
@@ -832,43 +832,43 @@ importers:
         version: 5.1.2
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.7.2
-        version: 6.7.2(@typescript-eslint/parser@6.7.2)(eslint@8.47.0)(typescript@5.2.2)
+        version: 6.7.2(@typescript-eslint/parser@6.7.2)(eslint@8.52.0)(typescript@5.2.2)
       '@typescript-eslint/parser':
         specifier: ^6.7.2
-        version: 6.7.2(eslint@8.47.0)(typescript@5.2.2)
+        version: 6.7.2(eslint@8.52.0)(typescript@5.2.2)
       '@vitejs/plugin-react':
         specifier: ^4.0.4
         version: 4.0.4(vite@4.5.0)
       eslint:
         specifier: ^8.47.0
-        version: 8.47.0
+        version: 8.52.0
       eslint-config-next:
         specifier: ^13.4.13
-        version: 13.4.13(eslint@8.47.0)(typescript@5.2.2)
+        version: 13.4.13(eslint@8.52.0)(typescript@5.2.2)
       eslint-config-prettier:
         specifier: ^9.0.0
-        version: 9.0.0(eslint@8.47.0)
+        version: 9.0.0(eslint@8.52.0)
       eslint-config-turbo:
         specifier: ^1.10.12
-        version: 1.10.12(eslint@8.47.0)
+        version: 1.10.12(eslint@8.52.0)
       eslint-plugin-no-secrets:
         specifier: ^0.8.9
-        version: 0.8.9(eslint@8.47.0)
+        version: 0.8.9(eslint@8.52.0)
       eslint-plugin-react:
         specifier: ^7.33.1
-        version: 7.33.1(eslint@8.47.0)
+        version: 7.33.2(eslint@8.52.0)
       eslint-plugin-sonarjs:
         specifier: ^0.20.0
-        version: 0.20.0(eslint@8.47.0)
+        version: 0.20.0(eslint@8.52.0)
       eslint-plugin-vitest:
         specifier: ^0.2.8
-        version: 0.2.8(eslint@8.47.0)(typescript@5.2.2)(vite@4.5.0)(vitest@0.34.1)
+        version: 0.2.8(eslint@8.52.0)(typescript@5.2.2)(vite@4.5.0)(vitest@0.34.1)
       jsdom:
         specifier: ^22.1.0
         version: 22.1.0
       next:
         specifier: '>=13'
-        version: 13.5.5(@babel/core@7.22.10)(react-dom@18.2.0)(react@18.2.0)
+        version: 13.5.5(@babel/core@7.23.2)(react-dom@18.2.0)(react@18.2.0)
       typescript:
         specifier: ^5.2.2
         version: 5.2.2
@@ -880,26 +880,26 @@ importers:
     dependencies:
       '@types/node':
         specifier: ^20.4.8
-        version: 20.4.8
+        version: 20.8.8
     devDependencies:
       '@evmosapps/config':
         specifier: workspace:*
         version: link:../config
       autoprefixer:
         specifier: ^10.4.13
-        version: 10.4.13(postcss@8.4.20)
+        version: 10.4.13(postcss@8.4.31)
       eslint-config-next:
         specifier: 13.0.6
         version: 13.0.6(eslint@8.52.0)(typescript@5.2.2)
       postcss:
         specifier: ^8.4.20
-        version: 8.4.20
+        version: 8.4.31
       prettier:
         specifier: ^3.0.1
         version: 3.0.1
       tsup:
         specifier: ^7.2.0
-        version: 7.2.0(postcss@8.4.20)(typescript@5.2.2)
+        version: 7.2.0(postcss@8.4.31)(typescript@5.2.2)
       typescript:
         specifier: ^5.2.2
         version: 5.2.2
@@ -920,7 +920,7 @@ importers:
         version: 1.9.5(react-redux@8.1.2)(react@18.2.0)
       '@tanstack/react-query':
         specifier: ^4.32.6
-        version: 4.32.6(react-dom@18.2.0)(react@18.2.0)
+        version: 4.36.1(react-dom@18.2.0)(react@18.2.0)
       '@testing-library/react':
         specifier: ^14.0.0
         version: 14.0.0(react-dom@18.2.0)(react@18.2.0)
@@ -947,7 +947,7 @@ importers:
         version: link:../constants-helper
       eslint:
         specifier: ^8.47.0
-        version: 8.47.0
+        version: 8.52.0
       ethers:
         specifier: ^6.7.1
         version: 6.7.1
@@ -996,10 +996,10 @@ importers:
         version: link:../config
       autoprefixer:
         specifier: ^10.4.13
-        version: 10.4.13(postcss@8.4.20)
+        version: 10.4.13(postcss@8.4.31)
       postcss:
         specifier: ^8.4.20
-        version: 8.4.20
+        version: 8.4.31
       prettier:
         specifier: ^3.0.1
         version: 3.0.1
@@ -1008,22 +1008,22 @@ importers:
         version: 1.19.0(@types/react@18.2.21)(react@18.2.0)
       tsup:
         specifier: ^7.2.0
-        version: 7.2.0(postcss@8.4.20)(typescript@5.2.2)
+        version: 7.2.0(postcss@8.4.31)(typescript@5.2.2)
 
   packages/evmos-wallet:
     dependencies:
       '@buf/cosmos_cosmos-sdk.bufbuild_es':
         specifier: 1.3.0-20230822104619-a12828247088.1
-        version: 1.3.0-20230822104619-a12828247088.1(@bufbuild/protobuf@1.3.0)
+        version: 1.3.0-20230822104619-a12828247088.1(@bufbuild/protobuf@1.4.0)
       '@buf/cosmos_ibc.bufbuild_es':
         specifier: 1.3.0-20230814193404-fc08c08e8082.1
-        version: 1.3.0-20230814193404-fc08c08e8082.1(@bufbuild/protobuf@1.3.0)
+        version: 1.3.0-20230814193404-fc08c08e8082.1(@bufbuild/protobuf@1.4.0)
       '@buf/evmos_evmos.bufbuild_es':
         specifier: 1.3.0-20230822152208-9101da12dca9.1
-        version: 1.3.0-20230822152208-9101da12dca9.1(@bufbuild/protobuf@1.3.0)
+        version: 1.3.0-20230822152208-9101da12dca9.1(@bufbuild/protobuf@1.4.0)
       '@bufbuild/protobuf':
         specifier: ^1.3.0
-        version: 1.3.0
+        version: 1.4.0
       '@cosmjs/stargate':
         specifier: ^0.31.1
         version: 0.31.1
@@ -1044,7 +1044,7 @@ importers:
         version: 5.7.0
       '@evmos/proto':
         specifier: ^0.1.26
-        version: 0.1.26
+        version: 0.1.27
       '@evmos/provider':
         specifier: ^0.2.8
         version: 0.2.8
@@ -1059,7 +1059,7 @@ importers:
         version: 1.0.1
       '@keplr-wallet/types':
         specifier: ^0.12.20
-        version: 0.12.20
+        version: 0.12.34
       '@metamask/providers':
         specifier: ^11.1.0
         version: 11.1.0
@@ -1071,7 +1071,7 @@ importers:
         version: 1.9.5(react-redux@8.1.2)(react@18.2.0)
       '@tanstack/react-query':
         specifier: ^4.32.6
-        version: 4.32.6(react-dom@18.2.0)(react@18.2.0)
+        version: 4.36.1(react-dom@18.2.0)(react@18.2.0)
       '@types/lodash-es':
         specifier: ^4.17.8
         version: 4.17.8
@@ -1089,7 +1089,7 @@ importers:
         version: 0.8.0
       eslint:
         specifier: ^8.47.0
-        version: 8.47.0
+        version: 8.52.0
       lodash-es:
         specifier: ^4.17.21
         version: 4.17.21
@@ -1141,7 +1141,7 @@ importers:
         version: 18.0.9
       '@walletconnect/modal':
         specifier: ^2.6.1
-        version: 2.6.1(react@18.2.0)
+        version: 2.6.2(@types/react@18.2.21)(react@18.2.0)
       autoprefixer:
         specifier: ^10.4.13
         version: 10.4.13(postcss@8.4.31)
@@ -1220,10 +1220,10 @@ importers:
         version: 18.0.9
       autoprefixer:
         specifier: ^10.4.13
-        version: 10.4.13(postcss@8.4.20)
+        version: 10.4.13(postcss@8.4.31)
       postcss:
         specifier: ^8.4.20
-        version: 8.4.20
+        version: 8.4.31
       prettier:
         specifier: ^3.0.1
         version: 3.0.1
@@ -1232,7 +1232,7 @@ importers:
         version: link:../tailwind-config
       tsup:
         specifier: ^7.2.0
-        version: 7.2.0(postcss@8.4.20)(typescript@5.2.2)
+        version: 7.2.0(postcss@8.4.31)(typescript@5.2.2)
       typescript:
         specifier: ^5.2.2
         version: 5.2.2
@@ -1254,10 +1254,10 @@ importers:
         version: 18.2.21
       autoprefixer:
         specifier: ^10.4.13
-        version: 10.4.13(postcss@8.4.20)
+        version: 10.4.13(postcss@8.4.31)
       postcss:
         specifier: ^8.4.20
-        version: 8.4.20
+        version: 8.4.31
       prettier:
         specifier: ^3.0.1
         version: 3.0.1
@@ -1266,7 +1266,7 @@ importers:
         version: link:../tailwind-config
       tsup:
         specifier: ^7.2.0
-        version: 7.2.0(postcss@8.4.20)(typescript@5.2.2)
+        version: 7.2.0(postcss@8.4.31)(typescript@5.2.2)
       typescript:
         specifier: ^5.2.2
         version: 5.2.2
@@ -1285,7 +1285,7 @@ importers:
         version: link:../config
       '@types/lodash':
         specifier: ^4.14.197
-        version: 4.14.197
+        version: 4.14.200
       '@types/lodash-es':
         specifier: ^4.17.8
         version: 4.17.8
@@ -1300,7 +1300,7 @@ importers:
         version: 8.12.0
       chain-token-registry:
         specifier: github:evmos/chain-token-registry#main
-        version: github.com/evmos/chain-token-registry/2be54462eec4f6f9fb876c3caeca11f7e4d6d898
+        version: github.com/evmos/chain-token-registry/1045012f8213925dc05027f7aeab9f94700c4aa7
       chalk:
         specifier: ^5.3.0
         version: 5.3.0
@@ -1349,10 +1349,10 @@ importers:
         version: 18.0.9
       autoprefixer:
         specifier: ^10.4.13
-        version: 10.4.13(postcss@8.4.20)
+        version: 10.4.13(postcss@8.4.31)
       postcss:
         specifier: ^8.4.20
-        version: 8.4.20
+        version: 8.4.31
       prettier:
         specifier: ^3.0.1
         version: 3.0.1
@@ -1361,7 +1361,7 @@ importers:
         version: link:../tailwind-config
       tsup:
         specifier: ^7.2.0
-        version: 7.2.0(postcss@8.4.20)(typescript@5.2.2)
+        version: 7.2.0(postcss@8.4.31)(typescript@5.2.2)
       typescript:
         specifier: ^5.2.2
         version: 5.2.2
@@ -1428,10 +1428,10 @@ importers:
         version: 18.0.9
       autoprefixer:
         specifier: ^10.4.13
-        version: 10.4.13(postcss@8.4.20)
+        version: 10.4.13(postcss@8.4.31)
       postcss:
         specifier: ^8.4.20
-        version: 8.4.20
+        version: 8.4.31
       prettier:
         specifier: ^3.0.1
         version: 3.0.1
@@ -1449,7 +1449,7 @@ importers:
         version: link:../tailwind-config
       tsup:
         specifier: ^7.2.0
-        version: 7.2.0(postcss@8.4.20)(typescript@5.2.2)
+        version: 7.2.0(postcss@8.4.31)(typescript@5.2.2)
       typescript:
         specifier: ^5.2.2
         version: 5.2.2
@@ -1462,7 +1462,7 @@ importers:
     devDependencies:
       tailwindcss:
         specifier: ^3.3.3
-        version: 3.3.3
+        version: 3.3.4
 
   packages/test-utils:
     dependencies:
@@ -1574,7 +1574,7 @@ importers:
         version: 1.0.34
       ws:
         specifier: ^8.14.2
-        version: 8.14.2
+        version: 8.14.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)
     devDependencies:
       '@evmosapps/config':
         specifier: workspace:*
@@ -1636,7 +1636,7 @@ importers:
         version: 18.0.9
       tsup:
         specifier: ^7.2.0
-        version: 7.2.0(postcss@8.4.20)(typescript@5.2.2)
+        version: 7.2.0(postcss@8.4.31)(typescript@5.2.2)
       typescript:
         specifier: ^5.2.2
         version: 5.2.2
@@ -1645,7 +1645,7 @@ importers:
     dependencies:
       '@tanstack/react-query':
         specifier: ^4.32.6
-        version: 4.32.6(react-dom@18.2.0)(react@18.2.0)
+        version: 4.36.1(react-dom@18.2.0)(react@18.2.0)
       '@testing-library/react':
         specifier: ^14.0.0
         version: 14.0.0(react-dom@18.2.0)(react@18.2.0)
@@ -1697,10 +1697,10 @@ importers:
         version: 18.0.9
       autoprefixer:
         specifier: ^10.4.13
-        version: 10.4.13(postcss@8.4.20)
+        version: 10.4.13(postcss@8.4.31)
       postcss:
         specifier: ^8.4.20
-        version: 8.4.20
+        version: 8.4.31
       prettier:
         specifier: ^3.0.1
         version: 3.0.1
@@ -1709,7 +1709,7 @@ importers:
         version: link:../tailwind-config
       tsup:
         specifier: ^7.2.0
-        version: 7.2.0(postcss@8.4.20)(typescript@5.2.2)
+        version: 7.2.0(postcss@8.4.31)(typescript@5.2.2)
       typescript:
         specifier: ^5.2.2
         version: 5.2.2
@@ -1738,14 +1738,14 @@ packages:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.20
 
-  /@babel/cli@7.22.10(@babel/core@7.22.10):
+  /@babel/cli@7.22.10(@babel/core@7.23.2):
     resolution: {integrity: sha512-rM9ZMmaII630zGvtMtQ3P4GyHs28CHLYE9apLG7L8TgaSqcfoIGrlLSLsh4Q8kDTdZQQEXZm1M0nQtOvU/2heg==}
     engines: {node: '>=6.9.0'}
     hasBin: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@jridgewell/trace-mapping': 0.3.20
       commander: 4.1.1
       convert-source-map: 1.9.0
@@ -1781,29 +1781,6 @@ packages:
     resolution: {integrity: sha512-0S9TQMmDHlqAZ2ITT95irXKfxN9bncq8ZCoJhun3nHL/lLUxd2NKBJYoNGWH7S0hz6fRQwWlAWn/ILM0C70KZQ==}
     engines: {node: '>=6.9.0'}
 
-  /@babel/core@7.22.10:
-    resolution: {integrity: sha512-fTmqbbUBAwCcre6zPzNngvsI0aNrPZe77AeqvDxWM9Nm+04RrJ3CAmGHA9f7lJQY6ZMhRztNemy4uslDxTX4Qw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@ampproject/remapping': 2.2.1
-      '@babel/code-frame': 7.22.13
-      '@babel/generator': 7.23.0
-      '@babel/helper-compilation-targets': 7.22.15
-      '@babel/helper-module-transforms': 7.23.0(@babel/core@7.22.10)
-      '@babel/helpers': 7.23.2
-      '@babel/parser': 7.23.0
-      '@babel/template': 7.22.15
-      '@babel/traverse': 7.23.2(supports-color@5.5.0)
-      '@babel/types': 7.23.0
-      convert-source-map: 1.9.0
-      debug: 4.3.4(supports-color@5.5.0)
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /@babel/core@7.23.2:
     resolution: {integrity: sha512-n7s51eWdaWZ3vGT2tD4T7J6eJs3QoBXydv7vkUM06Bf1cbVD2Kc2UrkzhiQwobfV7NwOnQXYL7UBJ5VPU+RGoQ==}
     engines: {node: '>=6.9.0'}
@@ -1826,16 +1803,16 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/eslint-parser@7.22.10(@babel/core@7.22.10)(eslint@8.47.0):
+  /@babel/eslint-parser@7.22.10(@babel/core@7.23.2)(eslint@8.52.0):
     resolution: {integrity: sha512-0J8DNPRXQRLeR9rPaUMM3fA+RbixjnVLe/MRMYCkp3hzgsSuxCHQ8NN8xQG1wIHKJ4a1DTROTvFJdW+B5/eOsg==}
     engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
     peerDependencies:
       '@babel/core': ^7.11.0
       eslint: ^7.5.0 || ^8.0.0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
-      eslint: 8.47.0
+      eslint: 8.52.0
       eslint-visitor-keys: 2.1.0
       semver: 6.3.1
     dev: false
@@ -1873,42 +1850,42 @@ packages:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  /@babel/helper-create-class-features-plugin@7.22.15(@babel/core@7.22.10):
+  /@babel/helper-create-class-features-plugin@7.22.15(@babel/core@7.23.2):
     resolution: {integrity: sha512-jKkwA59IXcvSaiK2UN45kKwSC9o+KuoXsBDvHvU/7BecYIp8GQ2UwrVvFgJASUT+hBnwJx6MhvMCuMzwZZ7jlg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-member-expression-to-functions': 7.23.0
       '@babel/helper-optimise-call-expression': 7.22.5
-      '@babel/helper-replace-supers': 7.22.20(@babel/core@7.22.10)
+      '@babel/helper-replace-supers': 7.22.20(@babel/core@7.23.2)
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
       semver: 6.3.1
     dev: false
 
-  /@babel/helper-create-regexp-features-plugin@7.22.15(@babel/core@7.22.10):
+  /@babel/helper-create-regexp-features-plugin@7.22.15(@babel/core@7.23.2):
     resolution: {integrity: sha512-29FkPLFjn4TPEa3RE7GpW+qbE8tlsu3jntNYNfcGsc49LphF1PQIiD+vMZ1z1xVOKt+93khA9tc2JBs3kBjA7w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-annotate-as-pure': 7.22.5
       regexpu-core: 5.3.2
       semver: 6.3.1
     dev: false
 
-  /@babel/helper-define-polyfill-provider@0.4.3(@babel/core@7.22.10):
+  /@babel/helper-define-polyfill-provider@0.4.3(@babel/core@7.23.2):
     resolution: {integrity: sha512-WBrLmuPP47n7PNwsZ57pqam6G/RGo1vw/87b0Blc53tZNGZ4x7YvZ6HgQe2vo1W/FR20OgjeZuGXzudPiXHFug==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-compilation-targets': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
       debug: 4.3.4(supports-color@5.5.0)
@@ -1948,20 +1925,6 @@ packages:
     dependencies:
       '@babel/types': 7.23.0
 
-  /@babel/helper-module-transforms@7.23.0(@babel/core@7.22.10):
-    resolution: {integrity: sha512-WhDWw1tdrlT0gMgUJSlX0IQvoO1eN279zrAUbVB+KpV2c3Tylz8+GnKOLllCS6Z/iZQEyVYxhZVUdPTqs2YYPw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.22.10
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-module-imports': 7.22.15
-      '@babel/helper-simple-access': 7.22.5
-      '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/helper-validator-identifier': 7.22.20
-    dev: false
-
   /@babel/helper-module-transforms@7.23.0(@babel/core@7.23.2):
     resolution: {integrity: sha512-WhDWw1tdrlT0gMgUJSlX0IQvoO1eN279zrAUbVB+KpV2c3Tylz8+GnKOLllCS6Z/iZQEyVYxhZVUdPTqs2YYPw==}
     engines: {node: '>=6.9.0'}
@@ -1987,25 +1950,25 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: false
 
-  /@babel/helper-remap-async-to-generator@7.22.20(@babel/core@7.22.10):
+  /@babel/helper-remap-async-to-generator@7.22.20(@babel/core@7.23.2):
     resolution: {integrity: sha512-pBGyV4uBqOns+0UvhsTO8qgl8hO89PmiDYv+/COyp1aeMcmfrfruz+/nCMFiYyFF/Knn0yfrC85ZzNFjembFTw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-wrap-function': 7.22.20
     dev: false
 
-  /@babel/helper-replace-supers@7.22.20(@babel/core@7.22.10):
+  /@babel/helper-replace-supers@7.22.20(@babel/core@7.23.2):
     resolution: {integrity: sha512-qsW0In3dbwQUbK8kejJ4R7IHVGwHJlV6lpG6UA7a9hSa2YEiAib+N1T2kr6PEeUT+Fl7najmSOS6SmAwCHK6Tw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-member-expression-to-functions': 7.23.0
       '@babel/helper-optimise-call-expression': 7.22.5
@@ -2076,90 +2039,80 @@ packages:
     dependencies:
       '@babel/types': 7.23.0
 
-  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.22.15(@babel/core@7.22.10):
+  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.22.15(@babel/core@7.23.2):
     resolution: {integrity: sha512-FB9iYlz7rURmRJyXRKEnalYPPdn87H5no108cyuQQyMwlpJ2SJtpIUBI27kdTin956pz+LPypkPVPUTlxOmrsg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.22.15(@babel/core@7.22.10):
+  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.22.15(@babel/core@7.23.2):
     resolution: {integrity: sha512-Hyph9LseGvAeeXzikV88bczhsrLrIZqDPxO+sSmAunMPaGrBGhfMWzCPYTtiW9t+HzSE2wtV8e5cc5P6r1xMDQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.13.0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-      '@babel/plugin-transform-optional-chaining': 7.23.0(@babel/core@7.22.10)
+      '@babel/plugin-transform-optional-chaining': 7.23.0(@babel/core@7.23.2)
     dev: false
 
-  /@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.22.10):
+  /@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.23.2):
     resolution: {integrity: sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
     dev: false
 
-  /@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.22.10):
+  /@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.23.2):
     resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.22.10):
+  /@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.23.2):
     resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.22.10):
+  /@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.22.10):
+  /@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.23.2):
     resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.22.10):
+  /@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.23.2):
     resolution: {integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
-      '@babel/helper-plugin-utils': 7.22.5
-    dev: false
-
-  /@babel/plugin-syntax-import-assertions@7.22.5(@babel/core@7.22.10):
-    resolution: {integrity: sha512-rdV97N7KqsRzeNGoWUOK6yUsWarLjE5Su/Snk9IYPU9CwkWHs4t+rTGOvffTR8XGkJMTAdLfO0xVnXm8wugIJg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
@@ -2173,31 +2126,31 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-syntax-import-attributes@7.22.5(@babel/core@7.22.10):
+  /@babel/plugin-syntax-import-attributes@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-KwvoWDeNKPETmozyFE0P2rOLqh39EoQHNjqizrI5B8Vt0ZNS7M56s7dAiAqbYfiAYOuIzIh96z3iR2ktgu3tEg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.22.10):
+  /@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.23.2):
     resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.22.10):
+  /@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.23.2):
     resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
@@ -2211,740 +2164,740 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.22.10):
+  /@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.23.2):
     resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.22.10):
+  /@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.23.2):
     resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.22.10):
+  /@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.23.2):
     resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.22.10):
+  /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.23.2):
     resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.22.10):
+  /@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.23.2):
     resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.22.10):
+  /@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.23.2):
     resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.22.10):
+  /@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.22.10):
+  /@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.22.10):
+  /@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.23.2):
     resolution: {integrity: sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.10
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.22.10)
+      '@babel/core': 7.23.2
+      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-arrow-functions@7.22.5(@babel/core@7.22.10):
+  /@babel/plugin-transform-arrow-functions@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-26lTNXoVRdAnsaDXPpvCNUq+OVWEVC6bx7Vvz9rC53F2bagUWW4u4ii2+h8Fejfh7RYqPxn+libeFBBck9muEw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-async-generator-functions@7.23.2(@babel/core@7.22.10):
+  /@babel/plugin-transform-async-generator-functions@7.23.2(@babel/core@7.23.2):
     resolution: {integrity: sha512-BBYVGxbDVHfoeXbOwcagAkOQAm9NxoTdMGfTqghu1GrvadSaw6iW3Je6IcL5PNOw8VwjxqBECXy50/iCQSY/lQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.22.10)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.22.10)
+      '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.23.2)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.23.2)
     dev: false
 
-  /@babel/plugin-transform-async-to-generator@7.22.5(@babel/core@7.22.10):
+  /@babel/plugin-transform-async-to-generator@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-b1A8D8ZzE/VhNDoV1MSJTnpKkCG5bJo+19R4o4oy03zM7ws8yEMK755j61Dc3EyvdysbqH5BOOTquJ7ZX9C6vQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.22.10)
+      '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.23.2)
     dev: false
 
-  /@babel/plugin-transform-block-scoped-functions@7.22.5(@babel/core@7.22.10):
+  /@babel/plugin-transform-block-scoped-functions@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-tdXZ2UdknEKQWKJP1KMNmuF5Lx3MymtMN/pvA+p/VEkhK8jVcQ1fzSy8KM9qRYhAf2/lV33hoMPKI/xaI9sADA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-block-scoping@7.23.0(@babel/core@7.22.10):
+  /@babel/plugin-transform-block-scoping@7.23.0(@babel/core@7.23.2):
     resolution: {integrity: sha512-cOsrbmIOXmf+5YbL99/S49Y3j46k/T16b9ml8bm9lP6N9US5iQ2yBK7gpui1pg0V/WMcXdkfKbTb7HXq9u+v4g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-class-properties@7.22.5(@babel/core@7.22.10):
+  /@babel/plugin-transform-class-properties@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-nDkQ0NfkOhPTq8YCLiWNxp1+f9fCobEjCb0n8WdbNUBc4IB5V7P1QnX9IjpSoquKrXF5SKojHleVNs2vGeHCHQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
-      '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.22.10)
+      '@babel/core': 7.23.2
+      '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-class-static-block@7.22.11(@babel/core@7.22.10):
+  /@babel/plugin-transform-class-static-block@7.22.11(@babel/core@7.23.2):
     resolution: {integrity: sha512-GMM8gGmqI7guS/llMFk1bJDkKfn3v3C4KHK9Yg1ey5qcHcOlKb0QvcMrgzvxo+T03/4szNh5lghY+fEC98Kq9g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.12.0
     dependencies:
-      '@babel/core': 7.22.10
-      '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.22.10)
+      '@babel/core': 7.23.2
+      '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.22.10)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.23.2)
     dev: false
 
-  /@babel/plugin-transform-classes@7.22.15(@babel/core@7.22.10):
+  /@babel/plugin-transform-classes@7.22.15(@babel/core@7.23.2):
     resolution: {integrity: sha512-VbbC3PGjBdE0wAWDdHM9G8Gm977pnYI0XpqMd6LrKISj8/DJXEsWqgRuTYaNE9Bv0JGhTZUzHDlMk18IpOuoqw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-compilation-targets': 7.22.15
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-optimise-call-expression': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-replace-supers': 7.22.20(@babel/core@7.22.10)
+      '@babel/helper-replace-supers': 7.22.20(@babel/core@7.23.2)
       '@babel/helper-split-export-declaration': 7.22.6
       globals: 11.12.0
     dev: false
 
-  /@babel/plugin-transform-computed-properties@7.22.5(@babel/core@7.22.10):
+  /@babel/plugin-transform-computed-properties@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-4GHWBgRf0krxPX+AaPtgBAlTgTeZmqDynokHOX7aqqAB4tHs3U2Y02zH6ETFdLZGcg9UQSD1WCmkVrE9ErHeOg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/template': 7.22.15
     dev: false
 
-  /@babel/plugin-transform-destructuring@7.23.0(@babel/core@7.22.10):
+  /@babel/plugin-transform-destructuring@7.23.0(@babel/core@7.23.2):
     resolution: {integrity: sha512-vaMdgNXFkYrB+8lbgniSYWHsgqK5gjaMNcc84bMIOMRLH0L9AqYq3hwMdvnyqj1OPqea8UtjPEuS/DCenah1wg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-dotall-regex@7.22.5(@babel/core@7.22.10):
+  /@babel/plugin-transform-dotall-regex@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-5/Yk9QxCQCl+sOIB1WelKnVRxTJDSAIxtJLL2/pqL14ZVlbH0fUQUZa/T5/UnQtBNgghR7mfB8ERBKyKPCi7Vw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.22.10)
+      '@babel/core': 7.23.2
+      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-duplicate-keys@7.22.5(@babel/core@7.22.10):
+  /@babel/plugin-transform-duplicate-keys@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-dEnYD+9BBgld5VBXHnF/DbYGp3fqGMsyxKbtD1mDyIA7AkTSpKXFhCVuj/oQVOoALfBs77DudA0BE4d5mcpmqw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-dynamic-import@7.22.11(@babel/core@7.22.10):
+  /@babel/plugin-transform-dynamic-import@7.22.11(@babel/core@7.23.2):
     resolution: {integrity: sha512-g/21plo58sfteWjaO0ZNVb+uEOkJNjAaHhbejrnBmu011l/eNDScmkbjCC3l4FKb10ViaGU4aOkFznSu2zRHgA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.22.10)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.23.2)
     dev: false
 
-  /@babel/plugin-transform-exponentiation-operator@7.22.5(@babel/core@7.22.10):
+  /@babel/plugin-transform-exponentiation-operator@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-vIpJFNM/FjZ4rh1myqIya9jXwrwwgFRHPjT3DkUA9ZLHuzox8jiXkOLvwm1H+PQIP3CqfC++WPKeuDi0Sjdj1g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-export-namespace-from@7.22.11(@babel/core@7.22.10):
+  /@babel/plugin-transform-export-namespace-from@7.22.11(@babel/core@7.23.2):
     resolution: {integrity: sha512-xa7aad7q7OiT8oNZ1mU7NrISjlSkVdMbNxn9IuLZyL9AJEhs1Apba3I+u5riX1dIkdptP5EKDG5XDPByWxtehw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.22.10)
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.23.2)
     dev: false
 
-  /@babel/plugin-transform-for-of@7.22.15(@babel/core@7.22.10):
+  /@babel/plugin-transform-for-of@7.22.15(@babel/core@7.23.2):
     resolution: {integrity: sha512-me6VGeHsx30+xh9fbDLLPi0J1HzmeIIyenoOQHuw2D4m2SAU3NrspX5XxJLBpqn5yrLzrlw2Iy3RA//Bx27iOA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-function-name@7.22.5(@babel/core@7.22.10):
+  /@babel/plugin-transform-function-name@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-UIzQNMS0p0HHiQm3oelztj+ECwFnj+ZRV4KnguvlsD2of1whUeM6o7wGNj6oLwcDoAXQ8gEqfgC24D+VdIcevg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-compilation-targets': 7.22.15
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-json-strings@7.22.11(@babel/core@7.22.10):
+  /@babel/plugin-transform-json-strings@7.22.11(@babel/core@7.23.2):
     resolution: {integrity: sha512-CxT5tCqpA9/jXFlme9xIBCc5RPtdDq3JpkkhgHQqtDdiTnTI0jtZ0QzXhr5DILeYifDPp2wvY2ad+7+hLMW5Pw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.22.10)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.23.2)
     dev: false
 
-  /@babel/plugin-transform-literals@7.22.5(@babel/core@7.22.10):
+  /@babel/plugin-transform-literals@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-fTLj4D79M+mepcw3dgFBTIDYpbcB9Sm0bpm4ppXPaO+U+PKFFyV9MGRvS0gvGw62sd10kT5lRMKXAADb9pWy8g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-logical-assignment-operators@7.22.11(@babel/core@7.22.10):
+  /@babel/plugin-transform-logical-assignment-operators@7.22.11(@babel/core@7.23.2):
     resolution: {integrity: sha512-qQwRTP4+6xFCDV5k7gZBF3C31K34ut0tbEcTKxlX/0KXxm9GLcO14p570aWxFvVzx6QAfPgq7gaeIHXJC8LswQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.22.10)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.23.2)
     dev: false
 
-  /@babel/plugin-transform-member-expression-literals@7.22.5(@babel/core@7.22.10):
+  /@babel/plugin-transform-member-expression-literals@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-RZEdkNtzzYCFl9SE9ATaUMTj2hqMb4StarOJLrZRbqqU4HSBE7UlBw9WBWQiDzrJZJdUWiMTVDI6Gv/8DPvfew==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-modules-amd@7.23.0(@babel/core@7.22.10):
+  /@babel/plugin-transform-modules-amd@7.23.0(@babel/core@7.23.2):
     resolution: {integrity: sha512-xWT5gefv2HGSm4QHtgc1sYPbseOyf+FFDo2JbpE25GWl5BqTGO9IMwTYJRoIdjsF85GE+VegHxSCUt5EvoYTAw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
-      '@babel/helper-module-transforms': 7.23.0(@babel/core@7.22.10)
+      '@babel/core': 7.23.2
+      '@babel/helper-module-transforms': 7.23.0(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-modules-commonjs@7.23.0(@babel/core@7.22.10):
+  /@babel/plugin-transform-modules-commonjs@7.23.0(@babel/core@7.23.2):
     resolution: {integrity: sha512-32Xzss14/UVc7k9g775yMIvkVK8xwKE0DPdP5JTapr3+Z9w4tzeOuLNY6BXDQR6BdnzIlXnCGAzsk/ICHBLVWQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
-      '@babel/helper-module-transforms': 7.23.0(@babel/core@7.22.10)
+      '@babel/core': 7.23.2
+      '@babel/helper-module-transforms': 7.23.0(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-simple-access': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-modules-systemjs@7.23.0(@babel/core@7.22.10):
+  /@babel/plugin-transform-modules-systemjs@7.23.0(@babel/core@7.23.2):
     resolution: {integrity: sha512-qBej6ctXZD2f+DhlOC9yO47yEYgUh5CZNz/aBoH4j/3NOlRfJXJbY7xDQCqQVf9KbrqGzIWER1f23doHGrIHFg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-hoist-variables': 7.22.5
-      '@babel/helper-module-transforms': 7.23.0(@babel/core@7.22.10)
+      '@babel/helper-module-transforms': 7.23.0(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-validator-identifier': 7.22.20
     dev: false
 
-  /@babel/plugin-transform-modules-umd@7.22.5(@babel/core@7.22.10):
+  /@babel/plugin-transform-modules-umd@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-+S6kzefN/E1vkSsKx8kmQuqeQsvCKCd1fraCM7zXm4SFoggI099Tr4G8U81+5gtMdUeMQ4ipdQffbKLX0/7dBQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
-      '@babel/helper-module-transforms': 7.23.0(@babel/core@7.22.10)
+      '@babel/core': 7.23.2
+      '@babel/helper-module-transforms': 7.23.0(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-named-capturing-groups-regex@7.22.5(@babel/core@7.22.10):
+  /@babel/plugin-transform-named-capturing-groups-regex@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-YgLLKmS3aUBhHaxp5hi1WJTgOUb/NCuDHzGT9z9WTt3YG+CPRhJs6nprbStx6DnWM4dh6gt7SU3sZodbZ08adQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.10
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.22.10)
+      '@babel/core': 7.23.2
+      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-new-target@7.22.5(@babel/core@7.22.10):
+  /@babel/plugin-transform-new-target@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-AsF7K0Fx/cNKVyk3a+DW0JLo+Ua598/NxMRvxDnkpCIGFh43+h/v2xyhRUYf6oD8gE4QtL83C7zZVghMjHd+iw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-nullish-coalescing-operator@7.22.11(@babel/core@7.22.10):
+  /@babel/plugin-transform-nullish-coalescing-operator@7.22.11(@babel/core@7.23.2):
     resolution: {integrity: sha512-YZWOw4HxXrotb5xsjMJUDlLgcDXSfO9eCmdl1bgW4+/lAGdkjaEvOnQ4p5WKKdUgSzO39dgPl0pTnfxm0OAXcg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.22.10)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.23.2)
     dev: false
 
-  /@babel/plugin-transform-numeric-separator@7.22.11(@babel/core@7.22.10):
+  /@babel/plugin-transform-numeric-separator@7.22.11(@babel/core@7.23.2):
     resolution: {integrity: sha512-3dzU4QGPsILdJbASKhF/V2TVP+gJya1PsueQCxIPCEcerqF21oEcrob4mzjsp2Py/1nLfF5m+xYNMDpmA8vffg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.22.10)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.23.2)
     dev: false
 
-  /@babel/plugin-transform-object-rest-spread@7.22.15(@babel/core@7.22.10):
+  /@babel/plugin-transform-object-rest-spread@7.22.15(@babel/core@7.23.2):
     resolution: {integrity: sha512-fEB+I1+gAmfAyxZcX1+ZUwLeAuuf8VIg67CTznZE0MqVFumWkh8xWtn58I4dxdVf080wn7gzWoF8vndOViJe9Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/compat-data': 7.23.2
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-compilation-targets': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.22.10)
-      '@babel/plugin-transform-parameters': 7.22.15(@babel/core@7.22.10)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.23.2)
+      '@babel/plugin-transform-parameters': 7.22.15(@babel/core@7.23.2)
     dev: false
 
-  /@babel/plugin-transform-object-super@7.22.5(@babel/core@7.22.10):
+  /@babel/plugin-transform-object-super@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-klXqyaT9trSjIUrcsYIfETAzmOEZL3cBYqOYLJxBHfMFFggmXOv+NYSX/Jbs9mzMVESw/WycLFPRx8ba/b2Ipw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-replace-supers': 7.22.20(@babel/core@7.22.10)
+      '@babel/helper-replace-supers': 7.22.20(@babel/core@7.23.2)
     dev: false
 
-  /@babel/plugin-transform-optional-catch-binding@7.22.11(@babel/core@7.22.10):
+  /@babel/plugin-transform-optional-catch-binding@7.22.11(@babel/core@7.23.2):
     resolution: {integrity: sha512-rli0WxesXUeCJnMYhzAglEjLWVDF6ahb45HuprcmQuLidBJFWjNnOzssk2kuc6e33FlLaiZhG/kUIzUMWdBKaQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.22.10)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.23.2)
     dev: false
 
-  /@babel/plugin-transform-optional-chaining@7.23.0(@babel/core@7.22.10):
+  /@babel/plugin-transform-optional-chaining@7.23.0(@babel/core@7.23.2):
     resolution: {integrity: sha512-sBBGXbLJjxTzLBF5rFWaikMnOGOk/BmK6vVByIdEggZ7Vn6CvWXZyRkkLFK6WE0IF8jSliyOkUN6SScFgzCM0g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.22.10)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.23.2)
     dev: false
 
-  /@babel/plugin-transform-parameters@7.22.15(@babel/core@7.22.10):
+  /@babel/plugin-transform-parameters@7.22.15(@babel/core@7.23.2):
     resolution: {integrity: sha512-hjk7qKIqhyzhhUvRT683TYQOFa/4cQKwQy7ALvTpODswN40MljzNDa0YldevS6tGbxwaEKVn502JmY0dP7qEtQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-private-methods@7.22.5(@babel/core@7.22.10):
+  /@babel/plugin-transform-private-methods@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-PPjh4gyrQnGe97JTalgRGMuU4icsZFnWkzicB/fUtzlKUqvsWBKEpPPfr5a2JiyirZkHxnAqkQMO5Z5B2kK3fA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
-      '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.22.10)
+      '@babel/core': 7.23.2
+      '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-private-property-in-object@7.22.11(@babel/core@7.22.10):
+  /@babel/plugin-transform-private-property-in-object@7.22.11(@babel/core@7.23.2):
     resolution: {integrity: sha512-sSCbqZDBKHetvjSwpyWzhuHkmW5RummxJBVbYLkGkaiTOWGxml7SXt0iWa03bzxFIx7wOj3g/ILRd0RcJKBeSQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.22.10)
+      '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.22.10)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.23.2)
     dev: false
 
-  /@babel/plugin-transform-property-literals@7.22.5(@babel/core@7.22.10):
+  /@babel/plugin-transform-property-literals@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-TiOArgddK3mK/x1Qwf5hay2pxI6wCZnvQqrFSqbtg1GLl2JcNMitVH/YnqjP+M31pLUeTfzY1HAXFDnUBV30rQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-react-jsx-self@7.22.5(@babel/core@7.22.10):
+  /@babel/plugin-transform-react-jsx-self@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-nTh2ogNUtxbiSbxaT4Ds6aXnXEipHweN9YRgOX/oNXdf0cCrGn/+2LozFa3lnPV5D90MkjhgckCPBrsoSc1a7g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-react-jsx-source@7.22.5(@babel/core@7.22.10):
+  /@babel/plugin-transform-react-jsx-source@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-yIiRO6yobeEIaI0RTbIr8iAK9FcBHLtZq0S89ZPjDLQXBA4xvghaKqI0etp/tF3htTM0sazJKKLz9oEiGRtu7w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-regenerator@7.22.10(@babel/core@7.22.10):
+  /@babel/plugin-transform-regenerator@7.22.10(@babel/core@7.23.2):
     resolution: {integrity: sha512-F28b1mDt8KcT5bUyJc/U9nwzw6cV+UmTeRlXYIl2TNqMMJif0Jeey9/RQ3C4NOd2zp0/TRsDns9ttj2L523rsw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
       regenerator-transform: 0.15.2
     dev: false
 
-  /@babel/plugin-transform-reserved-words@7.22.5(@babel/core@7.22.10):
+  /@babel/plugin-transform-reserved-words@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-DTtGKFRQUDm8svigJzZHzb/2xatPc6TzNvAIJ5GqOKDsGFYgAskjRulbR/vGsPKq3OPqtexnz327qYpP57RFyA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-shorthand-properties@7.22.5(@babel/core@7.22.10):
+  /@babel/plugin-transform-shorthand-properties@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-vM4fq9IXHscXVKzDv5itkO1X52SmdFBFcMIBZ2FRn2nqVYqw6dBexUgMvAjHW+KXpPPViD/Yo3GrDEBaRC0QYA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-spread@7.22.5(@babel/core@7.22.10):
+  /@babel/plugin-transform-spread@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-5ZzDQIGyvN4w8+dMmpohL6MBo+l2G7tfC/O2Dg7/hjpgeWvUx8FzfeOKxGog9IimPa4YekaQ9PlDqTLOljkcxg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-sticky-regex@7.22.5(@babel/core@7.22.10):
+  /@babel/plugin-transform-sticky-regex@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-zf7LuNpHG0iEeiyCNwX4j3gDg1jgt1k3ZdXBKbZSoA3BbGQGvMiSvfbZRR3Dr3aeJe3ooWFZxOOG3IRStYp2Bw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-template-literals@7.22.5(@babel/core@7.22.10):
+  /@babel/plugin-transform-template-literals@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-5ciOehRNf+EyUeewo8NkbQiUs4d6ZxiHo6BcBcnFlgiJfu16q0bQUw9Jvo0b0gBKFG1SMhDSjeKXSYuJLeFSMA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-typeof-symbol@7.22.5(@babel/core@7.22.10):
+  /@babel/plugin-transform-typeof-symbol@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-bYkI5lMzL4kPii4HHEEChkD0rkc+nvnlR6+o/qdqR6zrm0Sv/nodmyLhlq2DO0YKLUNd2VePmPRjJXSBh9OIdA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-unicode-escapes@7.22.10(@babel/core@7.22.10):
+  /@babel/plugin-transform-unicode-escapes@7.22.10(@babel/core@7.23.2):
     resolution: {integrity: sha512-lRfaRKGZCBqDlRU3UIFovdp9c9mEvlylmpod0/OatICsSfuQ9YFthRo1tpTkGsklEefZdqlEFdY4A2dwTb6ohg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-unicode-property-regex@7.22.5(@babel/core@7.22.10):
+  /@babel/plugin-transform-unicode-property-regex@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-HCCIb+CbJIAE6sXn5CjFQXMwkCClcOfPCzTlilJ8cUatfzwHlWQkbtV0zD338u9dZskwvuOYTuuaMaA8J5EI5A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.22.10)
+      '@babel/core': 7.23.2
+      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-unicode-regex@7.22.5(@babel/core@7.22.10):
+  /@babel/plugin-transform-unicode-regex@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-028laaOKptN5vHJf9/Arr/HiJekMd41hOEZYvNsrsXqJ7YPYuX2bQxh31fkZzGmq3YqHRJzYFFAVYvKfMPKqyg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.10
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.22.10)
+      '@babel/core': 7.23.2
+      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-unicode-sets-regex@7.22.5(@babel/core@7.22.10):
+  /@babel/plugin-transform-unicode-sets-regex@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-lhMfi4FC15j13eKrh3DnYHjpGj6UKQHtNKTbtc1igvAhRy4+kLhV07OpLcsN0VgDEw/MjAvJO4BdMJsHwMhzCg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.10
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.22.10)
+      '@babel/core': 7.23.2
+      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/preset-env@7.22.10(@babel/core@7.22.10):
+  /@babel/preset-env@7.22.10(@babel/core@7.23.2):
     resolution: {integrity: sha512-riHpLb1drNkpLlocmSyEg4oYJIQFeXAK/d7rI6mbD0XsvoTOOweXDmQPG/ErxsEhWk3rl3Q/3F6RFQlVFS8m0A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/compat-data': 7.23.2
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-compilation-targets': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-validator-option': 7.22.15
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.22.15(@babel/core@7.22.10)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.22.15(@babel/core@7.22.10)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.22.10)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.22.10)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.22.10)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.22.10)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.22.10)
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.22.10)
-      '@babel/plugin-syntax-import-assertions': 7.22.5(@babel/core@7.22.10)
-      '@babel/plugin-syntax-import-attributes': 7.22.5(@babel/core@7.22.10)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.22.10)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.22.10)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.22.10)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.22.10)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.22.10)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.22.10)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.22.10)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.22.10)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.22.10)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.22.10)
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.22.10)
-      '@babel/plugin-transform-arrow-functions': 7.22.5(@babel/core@7.22.10)
-      '@babel/plugin-transform-async-generator-functions': 7.23.2(@babel/core@7.22.10)
-      '@babel/plugin-transform-async-to-generator': 7.22.5(@babel/core@7.22.10)
-      '@babel/plugin-transform-block-scoped-functions': 7.22.5(@babel/core@7.22.10)
-      '@babel/plugin-transform-block-scoping': 7.23.0(@babel/core@7.22.10)
-      '@babel/plugin-transform-class-properties': 7.22.5(@babel/core@7.22.10)
-      '@babel/plugin-transform-class-static-block': 7.22.11(@babel/core@7.22.10)
-      '@babel/plugin-transform-classes': 7.22.15(@babel/core@7.22.10)
-      '@babel/plugin-transform-computed-properties': 7.22.5(@babel/core@7.22.10)
-      '@babel/plugin-transform-destructuring': 7.23.0(@babel/core@7.22.10)
-      '@babel/plugin-transform-dotall-regex': 7.22.5(@babel/core@7.22.10)
-      '@babel/plugin-transform-duplicate-keys': 7.22.5(@babel/core@7.22.10)
-      '@babel/plugin-transform-dynamic-import': 7.22.11(@babel/core@7.22.10)
-      '@babel/plugin-transform-exponentiation-operator': 7.22.5(@babel/core@7.22.10)
-      '@babel/plugin-transform-export-namespace-from': 7.22.11(@babel/core@7.22.10)
-      '@babel/plugin-transform-for-of': 7.22.15(@babel/core@7.22.10)
-      '@babel/plugin-transform-function-name': 7.22.5(@babel/core@7.22.10)
-      '@babel/plugin-transform-json-strings': 7.22.11(@babel/core@7.22.10)
-      '@babel/plugin-transform-literals': 7.22.5(@babel/core@7.22.10)
-      '@babel/plugin-transform-logical-assignment-operators': 7.22.11(@babel/core@7.22.10)
-      '@babel/plugin-transform-member-expression-literals': 7.22.5(@babel/core@7.22.10)
-      '@babel/plugin-transform-modules-amd': 7.23.0(@babel/core@7.22.10)
-      '@babel/plugin-transform-modules-commonjs': 7.23.0(@babel/core@7.22.10)
-      '@babel/plugin-transform-modules-systemjs': 7.23.0(@babel/core@7.22.10)
-      '@babel/plugin-transform-modules-umd': 7.22.5(@babel/core@7.22.10)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.22.10)
-      '@babel/plugin-transform-new-target': 7.22.5(@babel/core@7.22.10)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.22.11(@babel/core@7.22.10)
-      '@babel/plugin-transform-numeric-separator': 7.22.11(@babel/core@7.22.10)
-      '@babel/plugin-transform-object-rest-spread': 7.22.15(@babel/core@7.22.10)
-      '@babel/plugin-transform-object-super': 7.22.5(@babel/core@7.22.10)
-      '@babel/plugin-transform-optional-catch-binding': 7.22.11(@babel/core@7.22.10)
-      '@babel/plugin-transform-optional-chaining': 7.23.0(@babel/core@7.22.10)
-      '@babel/plugin-transform-parameters': 7.22.15(@babel/core@7.22.10)
-      '@babel/plugin-transform-private-methods': 7.22.5(@babel/core@7.22.10)
-      '@babel/plugin-transform-private-property-in-object': 7.22.11(@babel/core@7.22.10)
-      '@babel/plugin-transform-property-literals': 7.22.5(@babel/core@7.22.10)
-      '@babel/plugin-transform-regenerator': 7.22.10(@babel/core@7.22.10)
-      '@babel/plugin-transform-reserved-words': 7.22.5(@babel/core@7.22.10)
-      '@babel/plugin-transform-shorthand-properties': 7.22.5(@babel/core@7.22.10)
-      '@babel/plugin-transform-spread': 7.22.5(@babel/core@7.22.10)
-      '@babel/plugin-transform-sticky-regex': 7.22.5(@babel/core@7.22.10)
-      '@babel/plugin-transform-template-literals': 7.22.5(@babel/core@7.22.10)
-      '@babel/plugin-transform-typeof-symbol': 7.22.5(@babel/core@7.22.10)
-      '@babel/plugin-transform-unicode-escapes': 7.22.10(@babel/core@7.22.10)
-      '@babel/plugin-transform-unicode-property-regex': 7.22.5(@babel/core@7.22.10)
-      '@babel/plugin-transform-unicode-regex': 7.22.5(@babel/core@7.22.10)
-      '@babel/plugin-transform-unicode-sets-regex': 7.22.5(@babel/core@7.22.10)
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.22.10)
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.22.15(@babel/core@7.23.2)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.22.15(@babel/core@7.23.2)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.23.2)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.23.2)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.23.2)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.23.2)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.23.2)
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.23.2)
+      '@babel/plugin-syntax-import-assertions': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-syntax-import-attributes': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.23.2)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.23.2)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.23.2)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.23.2)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.23.2)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.23.2)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.23.2)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.23.2)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.23.2)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.23.2)
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.23.2)
+      '@babel/plugin-transform-arrow-functions': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-async-generator-functions': 7.23.2(@babel/core@7.23.2)
+      '@babel/plugin-transform-async-to-generator': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-block-scoped-functions': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-block-scoping': 7.23.0(@babel/core@7.23.2)
+      '@babel/plugin-transform-class-properties': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-class-static-block': 7.22.11(@babel/core@7.23.2)
+      '@babel/plugin-transform-classes': 7.22.15(@babel/core@7.23.2)
+      '@babel/plugin-transform-computed-properties': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-destructuring': 7.23.0(@babel/core@7.23.2)
+      '@babel/plugin-transform-dotall-regex': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-duplicate-keys': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-dynamic-import': 7.22.11(@babel/core@7.23.2)
+      '@babel/plugin-transform-exponentiation-operator': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-export-namespace-from': 7.22.11(@babel/core@7.23.2)
+      '@babel/plugin-transform-for-of': 7.22.15(@babel/core@7.23.2)
+      '@babel/plugin-transform-function-name': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-json-strings': 7.22.11(@babel/core@7.23.2)
+      '@babel/plugin-transform-literals': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-logical-assignment-operators': 7.22.11(@babel/core@7.23.2)
+      '@babel/plugin-transform-member-expression-literals': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-modules-amd': 7.23.0(@babel/core@7.23.2)
+      '@babel/plugin-transform-modules-commonjs': 7.23.0(@babel/core@7.23.2)
+      '@babel/plugin-transform-modules-systemjs': 7.23.0(@babel/core@7.23.2)
+      '@babel/plugin-transform-modules-umd': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-new-target': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.22.11(@babel/core@7.23.2)
+      '@babel/plugin-transform-numeric-separator': 7.22.11(@babel/core@7.23.2)
+      '@babel/plugin-transform-object-rest-spread': 7.22.15(@babel/core@7.23.2)
+      '@babel/plugin-transform-object-super': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-optional-catch-binding': 7.22.11(@babel/core@7.23.2)
+      '@babel/plugin-transform-optional-chaining': 7.23.0(@babel/core@7.23.2)
+      '@babel/plugin-transform-parameters': 7.22.15(@babel/core@7.23.2)
+      '@babel/plugin-transform-private-methods': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-private-property-in-object': 7.22.11(@babel/core@7.23.2)
+      '@babel/plugin-transform-property-literals': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-regenerator': 7.22.10(@babel/core@7.23.2)
+      '@babel/plugin-transform-reserved-words': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-shorthand-properties': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-spread': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-sticky-regex': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-template-literals': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-typeof-symbol': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-unicode-escapes': 7.22.10(@babel/core@7.23.2)
+      '@babel/plugin-transform-unicode-property-regex': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-unicode-regex': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-unicode-sets-regex': 7.22.5(@babel/core@7.23.2)
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.23.2)
       '@babel/types': 7.23.0
-      babel-plugin-polyfill-corejs2: 0.4.6(@babel/core@7.22.10)
-      babel-plugin-polyfill-corejs3: 0.8.6(@babel/core@7.22.10)
-      babel-plugin-polyfill-regenerator: 0.5.3(@babel/core@7.22.10)
+      babel-plugin-polyfill-corejs2: 0.4.6(@babel/core@7.23.2)
+      babel-plugin-polyfill-corejs3: 0.8.6(@babel/core@7.23.2)
+      babel-plugin-polyfill-regenerator: 0.5.3(@babel/core@7.23.2)
       core-js-compat: 3.33.1
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.22.10):
+  /@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.23.2):
     resolution: {integrity: sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.22.10
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/types': 7.23.0
       esutils: 2.0.3
@@ -2997,31 +2950,12 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: false
 
-  /@buf/cosmos_cosmos-proto.bufbuild_es@1.3.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.3.0):
-    resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-proto.bufbuild_es/-/cosmos_cosmos-proto.bufbuild_es-1.3.0-20211202220400-1935555c206d.1.tgz}
-    peerDependencies:
-      '@bufbuild/protobuf': ^1.3.0
-    dependencies:
-      '@bufbuild/protobuf': 1.3.0
-    dev: false
-
   /@buf/cosmos_cosmos-proto.bufbuild_es@1.3.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.4.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-proto.bufbuild_es/-/cosmos_cosmos-proto.bufbuild_es-1.3.0-20211202220400-1935555c206d.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.3.0
     dependencies:
       '@bufbuild/protobuf': 1.4.0
-    dev: false
-
-  /@buf/cosmos_cosmos-sdk.bufbuild_es@1.3.0-20221115045553-508e19f5f375.1(@bufbuild/protobuf@1.3.0):
-    resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.bufbuild_es/-/cosmos_cosmos-sdk.bufbuild_es-1.3.0-20221115045553-508e19f5f375.1.tgz}
-    peerDependencies:
-      '@bufbuild/protobuf': ^1.3.0
-    dependencies:
-      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.3.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.3.0)
-      '@buf/cosmos_gogo-proto.bufbuild_es': 1.3.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.3.0)
-      '@buf/googleapis_googleapis.bufbuild_es': 1.3.0-20221025150512-783e4b5374fa.1(@bufbuild/protobuf@1.3.0)
-      '@bufbuild/protobuf': 1.3.0
     dev: false
 
   /@buf/cosmos_cosmos-sdk.bufbuild_es@1.3.0-20221115045553-508e19f5f375.1(@bufbuild/protobuf@1.4.0):
@@ -3035,26 +2969,15 @@ packages:
       '@bufbuild/protobuf': 1.4.0
     dev: false
 
-  /@buf/cosmos_cosmos-sdk.bufbuild_es@1.3.0-20230316080531-954f7b05f384.1(@bufbuild/protobuf@1.3.0):
+  /@buf/cosmos_cosmos-sdk.bufbuild_es@1.3.0-20230316080531-954f7b05f384.1(@bufbuild/protobuf@1.4.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.bufbuild_es/-/cosmos_cosmos-sdk.bufbuild_es-1.3.0-20230316080531-954f7b05f384.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.3.0
     dependencies:
-      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.3.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.3.0)
-      '@buf/cosmos_gogo-proto.bufbuild_es': 1.3.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.3.0)
-      '@buf/googleapis_googleapis.bufbuild_es': 1.3.0-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.3.0)
-      '@bufbuild/protobuf': 1.3.0
-    dev: false
-
-  /@buf/cosmos_cosmos-sdk.bufbuild_es@1.3.0-20230822104619-a12828247088.1(@bufbuild/protobuf@1.3.0):
-    resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.bufbuild_es/-/cosmos_cosmos-sdk.bufbuild_es-1.3.0-20230822104619-a12828247088.1.tgz}
-    peerDependencies:
-      '@bufbuild/protobuf': ^1.3.0
-    dependencies:
-      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.3.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.3.0)
-      '@buf/cosmos_gogo-proto.bufbuild_es': 1.3.0-20230509103710-5e5b9fdd0180.1(@bufbuild/protobuf@1.3.0)
-      '@buf/googleapis_googleapis.bufbuild_es': 1.3.0-20230502210827-cc916c318597.1(@bufbuild/protobuf@1.3.0)
-      '@bufbuild/protobuf': 1.3.0
+      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.3.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.4.0)
+      '@buf/cosmos_gogo-proto.bufbuild_es': 1.3.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.4.0)
+      '@buf/googleapis_googleapis.bufbuild_es': 1.3.0-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.4.0)
+      '@bufbuild/protobuf': 1.4.0
     dev: false
 
   /@buf/cosmos_cosmos-sdk.bufbuild_es@1.3.0-20230822104619-a12828247088.1(@bufbuild/protobuf@1.4.0):
@@ -3068,28 +2991,12 @@ packages:
       '@bufbuild/protobuf': 1.4.0
     dev: false
 
-  /@buf/cosmos_gogo-proto.bufbuild_es@1.3.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.3.0):
-    resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.bufbuild_es/-/cosmos_gogo-proto.bufbuild_es-1.3.0-20221020125208-34d970b699f8.1.tgz}
-    peerDependencies:
-      '@bufbuild/protobuf': ^1.3.0
-    dependencies:
-      '@bufbuild/protobuf': 1.3.0
-    dev: false
-
   /@buf/cosmos_gogo-proto.bufbuild_es@1.3.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.4.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.bufbuild_es/-/cosmos_gogo-proto.bufbuild_es-1.3.0-20221020125208-34d970b699f8.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.3.0
     dependencies:
       '@bufbuild/protobuf': 1.4.0
-    dev: false
-
-  /@buf/cosmos_gogo-proto.bufbuild_es@1.3.0-20230509103710-5e5b9fdd0180.1(@bufbuild/protobuf@1.3.0):
-    resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.bufbuild_es/-/cosmos_gogo-proto.bufbuild_es-1.3.0-20230509103710-5e5b9fdd0180.1.tgz}
-    peerDependencies:
-      '@bufbuild/protobuf': ^1.3.0
-    dependencies:
-      '@bufbuild/protobuf': 1.3.0
     dev: false
 
   /@buf/cosmos_gogo-proto.bufbuild_es@1.3.0-20230509103710-5e5b9fdd0180.1(@bufbuild/protobuf@1.4.0):
@@ -3100,37 +3007,25 @@ packages:
       '@bufbuild/protobuf': 1.4.0
     dev: false
 
-  /@buf/cosmos_ibc.bufbuild_es@1.3.0-20230814193404-fc08c08e8082.1(@bufbuild/protobuf@1.3.0):
+  /@buf/cosmos_ibc.bufbuild_es@1.3.0-20230814193404-fc08c08e8082.1(@bufbuild/protobuf@1.4.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_ibc.bufbuild_es/-/cosmos_ibc.bufbuild_es-1.3.0-20230814193404-fc08c08e8082.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.3.0
     dependencies:
-      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.3.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.3.0)
-      '@buf/cosmos_cosmos-sdk.bufbuild_es': 1.3.0-20230316080531-954f7b05f384.1(@bufbuild/protobuf@1.3.0)
-      '@buf/cosmos_gogo-proto.bufbuild_es': 1.3.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.3.0)
-      '@buf/cosmos_ics23.bufbuild_es': 1.3.0-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.3.0)
-      '@buf/googleapis_googleapis.bufbuild_es': 1.3.0-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.3.0)
-      '@bufbuild/protobuf': 1.3.0
+      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.3.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.4.0)
+      '@buf/cosmos_cosmos-sdk.bufbuild_es': 1.3.0-20230316080531-954f7b05f384.1(@bufbuild/protobuf@1.4.0)
+      '@buf/cosmos_gogo-proto.bufbuild_es': 1.3.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.4.0)
+      '@buf/cosmos_ics23.bufbuild_es': 1.3.0-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.4.0)
+      '@buf/googleapis_googleapis.bufbuild_es': 1.3.0-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.4.0)
+      '@bufbuild/protobuf': 1.4.0
     dev: false
 
-  /@buf/cosmos_ics23.bufbuild_es@1.3.0-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.3.0):
+  /@buf/cosmos_ics23.bufbuild_es@1.3.0-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.4.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_ics23.bufbuild_es/-/cosmos_ics23.bufbuild_es-1.3.0-20221207100654-55085f7c710a.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.3.0
     dependencies:
-      '@bufbuild/protobuf': 1.3.0
-    dev: false
-
-  /@buf/evmos_evmos.bufbuild_es@1.3.0-20230822152208-9101da12dca9.1(@bufbuild/protobuf@1.3.0):
-    resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/evmos_evmos.bufbuild_es/-/evmos_evmos.bufbuild_es-1.3.0-20230822152208-9101da12dca9.1.tgz}
-    peerDependencies:
-      '@bufbuild/protobuf': ^1.3.0
-    dependencies:
-      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.3.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.3.0)
-      '@buf/cosmos_cosmos-sdk.bufbuild_es': 1.3.0-20221115045553-508e19f5f375.1(@bufbuild/protobuf@1.3.0)
-      '@buf/cosmos_gogo-proto.bufbuild_es': 1.3.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.3.0)
-      '@buf/googleapis_googleapis.bufbuild_es': 1.3.0-20221025150512-783e4b5374fa.1(@bufbuild/protobuf@1.3.0)
-      '@bufbuild/protobuf': 1.3.0
+      '@bufbuild/protobuf': 1.4.0
     dev: false
 
   /@buf/evmos_evmos.bufbuild_es@1.3.0-20230822152208-9101da12dca9.1(@bufbuild/protobuf@1.4.0):
@@ -3145,20 +3040,12 @@ packages:
       '@bufbuild/protobuf': 1.4.0
     dev: false
 
-  /@buf/googleapis_googleapis.bufbuild_es@1.3.0-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.3.0):
+  /@buf/googleapis_googleapis.bufbuild_es@1.3.0-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.4.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.3.0-20220908150232-8d7204855ec1.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.3.0
     dependencies:
-      '@bufbuild/protobuf': 1.3.0
-    dev: false
-
-  /@buf/googleapis_googleapis.bufbuild_es@1.3.0-20221025150512-783e4b5374fa.1(@bufbuild/protobuf@1.3.0):
-    resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.3.0-20221025150512-783e4b5374fa.1.tgz}
-    peerDependencies:
-      '@bufbuild/protobuf': ^1.3.0
-    dependencies:
-      '@bufbuild/protobuf': 1.3.0
+      '@bufbuild/protobuf': 1.4.0
     dev: false
 
   /@buf/googleapis_googleapis.bufbuild_es@1.3.0-20221025150512-783e4b5374fa.1(@bufbuild/protobuf@1.4.0):
@@ -3169,20 +3056,12 @@ packages:
       '@bufbuild/protobuf': 1.4.0
     dev: false
 
-  /@buf/googleapis_googleapis.bufbuild_es@1.3.0-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.3.0):
+  /@buf/googleapis_googleapis.bufbuild_es@1.3.0-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.4.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.3.0-20221214150216-75b4300737fb.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.3.0
     dependencies:
-      '@bufbuild/protobuf': 1.3.0
-    dev: false
-
-  /@buf/googleapis_googleapis.bufbuild_es@1.3.0-20230502210827-cc916c318597.1(@bufbuild/protobuf@1.3.0):
-    resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.3.0-20230502210827-cc916c318597.1.tgz}
-    peerDependencies:
-      '@bufbuild/protobuf': ^1.3.0
-    dependencies:
-      '@bufbuild/protobuf': 1.3.0
+      '@bufbuild/protobuf': 1.4.0
     dev: false
 
   /@buf/googleapis_googleapis.bufbuild_es@1.3.0-20230502210827-cc916c318597.1(@bufbuild/protobuf@1.4.0):
@@ -3191,10 +3070,6 @@ packages:
       '@bufbuild/protobuf': ^1.3.0
     dependencies:
       '@bufbuild/protobuf': 1.4.0
-    dev: false
-
-  /@bufbuild/protobuf@1.3.0:
-    resolution: {integrity: sha512-G372ods0pLt46yxVRsnP/e2btVPuuzArcMPFpIDeIwiGPuuglEs9y75iG0HMvZgncsj5TvbYRWqbVyOe3PLCWQ==}
     dev: false
 
   /@bufbuild/protobuf@1.4.0:
@@ -3616,16 +3491,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@eslint-community/eslint-utils@4.4.0(eslint@8.47.0):
-    resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-    dependencies:
-      eslint: 8.47.0
-      eslint-visitor-keys: 3.4.3
-    dev: false
-
   /@eslint-community/eslint-utils@4.4.0(eslint@8.52.0):
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -3634,28 +3499,10 @@ packages:
     dependencies:
       eslint: 8.52.0
       eslint-visitor-keys: 3.4.3
-    dev: true
 
   /@eslint-community/regexpp@4.9.1:
     resolution: {integrity: sha512-Y27x+MBLjXa+0JWDhykM3+JE+il3kHKAEqabfEWq3SDhZjLYb6/BHL/JKFnH3fe207JaXkyDo685Oc2Glt6ifA==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
-
-  /@eslint/eslintrc@2.1.1:
-    resolution: {integrity: sha512-9t7ZA7NGGK8ckelF0PQCfcxIUzs1Md5rrO6U/c+FIQNanea5UZC0wqKXH4vHBccmu4ZJgZ2idtPeW7+Q2npOEA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      ajv: 6.12.6
-      debug: 4.3.4(supports-color@5.5.0)
-      espree: 9.6.1
-      globals: 13.23.0
-      ignore: 5.2.4
-      import-fresh: 3.3.0
-      js-yaml: 4.1.0
-      minimatch: 3.1.2
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   /@eslint/eslintrc@2.1.2:
     resolution: {integrity: sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==}
@@ -3990,15 +3837,6 @@ packages:
       long: 5.2.3
       shx: 0.3.4
 
-  /@evmos/proto@0.1.26:
-    resolution: {integrity: sha512-AzlQTKHo6jRXl3s6aQp6QKrQPnwKhszrF50+ycnr13BDL57chV2BYDwBrEyh/1HtL/nuvIpgyMgSZTX7dyUt2g==}
-    requiresBuild: true
-    dependencies:
-      google-protobuf: 3.21.2
-      link-module-alias: 1.2.0
-      sha3: 2.1.4
-      shx: 0.3.4
-
   /@evmos/proto@0.1.27:
     resolution: {integrity: sha512-lBOZhQFsIUz3on/4H+Rj1aDj2OWaZnz7OJjUFklkPZQ3tEtAATBOQiVCjkPvIX3jh/H5DACahmi8BmhcNF+7UA==}
     requiresBuild: true
@@ -4020,7 +3858,7 @@ packages:
     requiresBuild: true
     dependencies:
       '@evmos/eip712': 0.2.11
-      '@evmos/proto': 0.1.26
+      '@evmos/proto': 0.1.27
       link-module-alias: 1.2.0
       shx: 0.3.4
 
@@ -4239,16 +4077,10 @@ packages:
     resolution: {integrity: sha512-lLwftuVZxATR3a7ZFm9N2+U/LIBaepRQMA3Md3RA9EBCUgf1Rq/znZbDc02WrEueYxNzsPG5HWHjpERic2DGnw==}
     dev: false
 
-  /@keplr-wallet/types@0.12.20:
-    resolution: {integrity: sha512-uCVu1WYv908eeK0Dlrltthf6cL9ThHdmmShhVXHx/ZzXUbRn1bfsEKwo83nggd5985XqdSiwXFmprskTHGO/pQ==}
-    dependencies:
-      long: 4.0.0
-
   /@keplr-wallet/types@0.12.34:
     resolution: {integrity: sha512-5QoT9ZLoqKARq2qqMnDpmof8V0CYAqSsspsfnuQXSDxHOeIB46Wrj4F+WuMoQbpJW4bt7k3ZHZGkoo2DC5WPoA==}
     dependencies:
       long: 4.0.0
-    dev: false
 
   /@keplr-wallet/unit@0.12.34:
     resolution: {integrity: sha512-qdg/P2hXaFqKiSVY1tc8wr+B8SYp8+Wu33hvHwIcsX91gbwjsbRWE1+xV0aQjpIhHcMZzNpSs6TklV7OWcySLQ==}
@@ -5262,38 +5094,20 @@ packages:
       remove-accents: 0.4.2
     dev: false
 
-  /@tanstack/query-core@4.32.6:
-    resolution: {integrity: sha512-YVB+mVWENQwPyv+40qO7flMgKZ0uI41Ph7qXC2Zf1ft5AIGfnXnMZyifB2ghhZ27u+5wm5mlzO4Y6lwwadzxCA==}
-
   /@tanstack/query-core@4.36.1:
     resolution: {integrity: sha512-DJSilV5+ytBP1FbFcEJovv4rnnm/CokuVvrBEtW/Va9DvuJ3HksbXUJEpI0aV1KtuL4ZoO9AVE6PyNLzF7tLeA==}
-    dev: true
-
-  /@tanstack/query-persist-client-core@4.32.6:
-    resolution: {integrity: sha512-MJJ7CldvT5HOel50h/3wOZZwVlIcroFD5Vxn8vPsfo2C0qQ208ilmN/81JWutm/lWy4n2BjnCrrWv6HvVI7S0w==}
-    dependencies:
-      '@tanstack/query-core': 4.32.6
-    dev: false
 
   /@tanstack/query-persist-client-core@4.36.1:
     resolution: {integrity: sha512-eocgCeI7D7TRv1IUUBMfVwOI0wdSmMkBIbkKhqEdTrnUHUQEeOaYac8oeZk2cumAWJdycu6P/wB+WqGynTnzXg==}
     dependencies:
       '@tanstack/query-core': 4.36.1
-    dev: true
-
-  /@tanstack/query-sync-storage-persister@4.32.6:
-    resolution: {integrity: sha512-hTwNo5O5EvydbfdVvwnwY0nIrNg1BxKEV4WAA8A+0NP9yc/9xoWy8RxbIkcz1p4JN2JhagaTKek8Fa5h5KitsA==}
-    dependencies:
-      '@tanstack/query-persist-client-core': 4.32.6
-    dev: false
 
   /@tanstack/query-sync-storage-persister@4.36.1:
     resolution: {integrity: sha512-yMEt5hWe2+1eclf1agMtXHnPIkxEida0lYWkfdhR8U6KXk/lO4Vca6piJmhKI85t0NHlx3l/z6zX+t/Fn5O9NA==}
     dependencies:
       '@tanstack/query-persist-client-core': 4.36.1
-    dev: true
 
-  /@tanstack/react-query-devtools@4.35.0(@tanstack/react-query@4.32.6)(react-dom@18.2.0)(react@18.2.0):
+  /@tanstack/react-query-devtools@4.35.0(@tanstack/react-query@4.36.1)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-tzN0K70idRsqnfLdUcQC3eCrv28kLIAB6/H1zsGdIw7Wmj5VgTxPmpEVc3rHQjKt0LZsvZTLmaLnI6FCI3VUZw==}
     peerDependencies:
       '@tanstack/react-query': ^4.35.0
@@ -5301,20 +5115,11 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
       '@tanstack/match-sorter-utils': 8.8.4
-      '@tanstack/react-query': 4.32.6(react-dom@18.2.0)(react@18.2.0)
+      '@tanstack/react-query': 4.36.1(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       superjson: 1.13.3
       use-sync-external-store: 1.2.0(react@18.2.0)
-    dev: false
-
-  /@tanstack/react-query-persist-client@4.32.6(@tanstack/react-query@4.32.6):
-    resolution: {integrity: sha512-EmNnYpvFYpxS4j5WFeNmfVVBxqq4RDnEFDBZwNKRfb4pzukcx/hcWtwqFk7Qj0EI4Dk8QGl239MEYwJbAc83tQ==}
-    peerDependencies:
-      '@tanstack/react-query': ^4.32.6
-    dependencies:
-      '@tanstack/query-persist-client-core': 4.32.6
-      '@tanstack/react-query': 4.32.6(react-dom@18.2.0)(react@18.2.0)
     dev: false
 
   /@tanstack/react-query-persist-client@4.36.1(@tanstack/react-query@4.36.1):
@@ -5324,24 +5129,6 @@ packages:
     dependencies:
       '@tanstack/query-persist-client-core': 4.36.1
       '@tanstack/react-query': 4.36.1(react-dom@18.2.0)(react@18.2.0)
-    dev: true
-
-  /@tanstack/react-query@4.32.6(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-AITu/IKJJJXsHHeXNBy5bclu12t08usMCY0vFC2dh9SP/w6JAk5U9GwfjOIPj3p+ATADZvxQPe8UiCtMLNeQbg==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-native: '*'
-    peerDependenciesMeta:
-      react-dom:
-        optional: true
-      react-native:
-        optional: true
-    dependencies:
-      '@tanstack/query-core': 4.32.6
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      use-sync-external-store: 1.2.0(react@18.2.0)
 
   /@tanstack/react-query@4.36.1(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-y7ySVHFyyQblPl3J3eQBWpXZkliroki3ARnBKsdJchlgt7yJLRDUcf4B8soufgiYt3pEQIkBWBx1N9/ZPIeUWw==}
@@ -5359,7 +5146,6 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       use-sync-external-store: 1.2.0(react@18.2.0)
-    dev: true
 
   /@tenkeylabs/dappwright@2.5.2(playwright-core@1.39.0):
     resolution: {integrity: sha512-90bYZxYDBKadsl783zqp6Sa+Kj4RJHK4RydDcaVjik5WD3xLwXgl0J/9ktCPXBvWHh/68ExvP4EadxOvdhfVag==}
@@ -5566,10 +5352,6 @@ packages:
     dependencies:
       '@types/lodash': 4.14.200
 
-  /@types/lodash@4.14.197:
-    resolution: {integrity: sha512-BMVOiWs0uNxHVlHBgzTIqJYmj+PgCo4euloGF+5m4okL3rEYzM2EEv78mw8zWSMM57dM7kVIgJ2QDvwHSoCI5g==}
-    dev: true
-
   /@types/lodash@4.14.200:
     resolution: {integrity: sha512-YI/M/4HRImtNf3pJgbF+W6FrXovqj+T+/HpENLTooK9PnkacBsDpeP3IpHab40CClUfhNmdM2WTNP2sa2dni5Q==}
 
@@ -5613,10 +5395,6 @@ packages:
   /@types/node@20.4.1:
     resolution: {integrity: sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg==}
     dev: true
-
-  /@types/node@20.4.8:
-    resolution: {integrity: sha512-0mHckf6D2DiIAzh8fM8f3HQCvMKDpK94YQ0DSVkfWTG9BZleYIWudw9cJxX8oCk9bM+vAkDyujDV6dmKHbvQpg==}
-    dev: false
 
   /@types/node@20.8.8:
     resolution: {integrity: sha512-YRsdVxq6OaLfmR9Hy816IMp33xOBjfyOgUd77ehqg96CFywxAPbDbXvAsuN2KVg2HOT8Eh6uAfU+l4WffwPVrQ==}
@@ -5693,7 +5471,7 @@ packages:
       '@types/node': 20.8.8
     dev: false
 
-  /@typescript-eslint/eslint-plugin@6.7.2(@typescript-eslint/parser@6.7.2)(eslint@8.47.0)(typescript@5.2.2):
+  /@typescript-eslint/eslint-plugin@6.7.2(@typescript-eslint/parser@6.7.2)(eslint@8.52.0)(typescript@5.2.2):
     resolution: {integrity: sha512-ooaHxlmSgZTM6CHYAFRlifqh1OAr3PAQEwi7lhYhaegbnXrnh7CDcHmc3+ihhbQC7H0i4JF0psI5ehzkF6Yl6Q==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -5705,13 +5483,13 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.9.1
-      '@typescript-eslint/parser': 6.7.2(eslint@8.47.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 6.7.2(eslint@8.52.0)(typescript@5.2.2)
       '@typescript-eslint/scope-manager': 6.7.2
-      '@typescript-eslint/type-utils': 6.7.2(eslint@8.47.0)(typescript@5.2.2)
-      '@typescript-eslint/utils': 6.7.2(eslint@8.47.0)(typescript@5.2.2)
+      '@typescript-eslint/type-utils': 6.7.2(eslint@8.52.0)(typescript@5.2.2)
+      '@typescript-eslint/utils': 6.7.2(eslint@8.52.0)(typescript@5.2.2)
       '@typescript-eslint/visitor-keys': 6.7.2
       debug: 4.3.4(supports-color@5.5.0)
-      eslint: 8.47.0
+      eslint: 8.52.0
       graphemer: 1.4.0
       ignore: 5.2.4
       natural-compare: 1.4.0
@@ -5742,7 +5520,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@6.7.2(eslint@8.47.0)(typescript@5.2.2):
+  /@typescript-eslint/parser@6.7.2(eslint@8.52.0)(typescript@5.2.2):
     resolution: {integrity: sha512-KA3E4ox0ws+SPyxQf9iSI25R6b4Ne78ORhNHeVKrPQnoYsb9UhieoiRoJgrzgEeKGOXhcY1i8YtOeCHHTDa6Fw==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -5757,7 +5535,7 @@ packages:
       '@typescript-eslint/typescript-estree': 6.7.2(typescript@5.2.2)
       '@typescript-eslint/visitor-keys': 6.7.2
       debug: 4.3.4(supports-color@5.5.0)
-      eslint: 8.47.0
+      eslint: 8.52.0
       typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
@@ -5787,7 +5565,7 @@ packages:
       '@typescript-eslint/visitor-keys': 6.9.0
     dev: false
 
-  /@typescript-eslint/type-utils@6.7.2(eslint@8.47.0)(typescript@5.2.2):
+  /@typescript-eslint/type-utils@6.7.2(eslint@8.52.0)(typescript@5.2.2):
     resolution: {integrity: sha512-36F4fOYIROYRl0qj95dYKx6kybddLtsbmPIYNK0OBeXv2j9L5nZ17j9jmfy+bIDHKQgn2EZX+cofsqi8NPATBQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -5798,9 +5576,9 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/typescript-estree': 6.7.2(typescript@5.2.2)
-      '@typescript-eslint/utils': 6.7.2(eslint@8.47.0)(typescript@5.2.2)
+      '@typescript-eslint/utils': 6.7.2(eslint@8.52.0)(typescript@5.2.2)
       debug: 4.3.4(supports-color@5.5.0)
-      eslint: 8.47.0
+      eslint: 8.52.0
       ts-api-utils: 1.0.3(typescript@5.2.2)
       typescript: 5.2.2
     transitivePeerDependencies:
@@ -5885,38 +5663,38 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/utils@6.7.2(eslint@8.47.0)(typescript@5.2.2):
+  /@typescript-eslint/utils@6.7.2(eslint@8.52.0)(typescript@5.2.2):
     resolution: {integrity: sha512-ZCcBJug/TS6fXRTsoTkgnsvyWSiXwMNiPzBUani7hDidBdj1779qwM1FIAmpH4lvlOZNF3EScsxxuGifjpLSWQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.47.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.52.0)
       '@types/json-schema': 7.0.14
       '@types/semver': 7.5.4
       '@typescript-eslint/scope-manager': 6.7.2
       '@typescript-eslint/types': 6.7.2
       '@typescript-eslint/typescript-estree': 6.7.2(typescript@5.2.2)
-      eslint: 8.47.0
+      eslint: 8.52.0
       semver: 7.5.4
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: false
 
-  /@typescript-eslint/utils@6.9.0(eslint@8.47.0)(typescript@5.2.2):
+  /@typescript-eslint/utils@6.9.0(eslint@8.52.0)(typescript@5.2.2):
     resolution: {integrity: sha512-5Wf+Jsqya7WcCO8me504FBigeQKVLAMPmUzYgDbWchINNh1KJbxCgVya3EQ2MjvJMVeXl3pofRmprqX6mfQkjQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.47.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.52.0)
       '@types/json-schema': 7.0.14
       '@types/semver': 7.5.4
       '@typescript-eslint/scope-manager': 6.9.0
       '@typescript-eslint/types': 6.9.0
       '@typescript-eslint/typescript-estree': 6.9.0(typescript@5.2.2)
-      eslint: 8.47.0
+      eslint: 8.52.0
       semver: 7.5.4
     transitivePeerDependencies:
       - supports-color
@@ -5949,7 +5727,6 @@ packages:
 
   /@ungap/structured-clone@1.2.0:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
-    dev: true
 
   /@vitejs/plugin-react@4.0.4(vite@4.5.0):
     resolution: {integrity: sha512-7wU921ABnNYkETiMaZy7XqpueMnpu5VxvVps13MjmCo+utBdD79sZzrApHawHtVX66cCJQQTXFcjH0y9dSUK8g==}
@@ -5957,9 +5734,9 @@ packages:
     peerDependencies:
       vite: ^4.2.0
     dependencies:
-      '@babel/core': 7.22.10
-      '@babel/plugin-transform-react-jsx-self': 7.22.5(@babel/core@7.22.10)
-      '@babel/plugin-transform-react-jsx-source': 7.22.5(@babel/core@7.22.10)
+      '@babel/core': 7.23.2
+      '@babel/plugin-transform-react-jsx-self': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-react-jsx-source': 7.22.5(@babel/core@7.23.2)
       react-refresh: 0.14.0
       vite: 4.5.0(@types/node@20.8.8)
     transitivePeerDependencies:
@@ -6299,31 +6076,12 @@ packages:
       tslib: 1.14.1
     dev: true
 
-  /@walletconnect/modal-core@2.6.1(react@18.2.0):
-    resolution: {integrity: sha512-f2hYlJ5pwzGvjyaZ6BoGR5uiMgXzWXt6w6ktt1N8lmY6PiYp8whZgqx2hTxVWwVlsGnaIfh6UHp1hGnANx0eTQ==}
-    dependencies:
-      valtio: 1.11.0(react@18.2.0)
-    transitivePeerDependencies:
-      - react
-    dev: true
-
   /@walletconnect/modal-core@2.6.2(@types/react@18.2.21)(react@18.2.0):
     resolution: {integrity: sha512-cv8ibvdOJQv2B+nyxP9IIFdxvQznMz8OOr/oR/AaUZym4hjXNL/l1a2UlSQBXrVjo3xxbouMxLb3kBsHoYP2CA==}
     dependencies:
       valtio: 1.11.2(@types/react@18.2.21)(react@18.2.0)
     transitivePeerDependencies:
       - '@types/react'
-      - react
-    dev: true
-
-  /@walletconnect/modal-ui@2.6.1(react@18.2.0):
-    resolution: {integrity: sha512-RFUOwDAMijSK8B7W3+KoLKaa1l+KEUG0LCrtHqaB0H0cLnhEGdLR+kdTdygw+W8+yYZbkM5tXBm7MlFbcuyitA==}
-    dependencies:
-      '@walletconnect/modal-core': 2.6.1(react@18.2.0)
-      lit: 2.7.6
-      motion: 10.16.2
-      qrcode: 1.5.3
-    transitivePeerDependencies:
       - react
     dev: true
 
@@ -6336,15 +6094,6 @@ packages:
       qrcode: 1.5.3
     transitivePeerDependencies:
       - '@types/react'
-      - react
-    dev: true
-
-  /@walletconnect/modal@2.6.1(react@18.2.0):
-    resolution: {integrity: sha512-G84tSzdPKAFk1zimgV7JzIUFT5olZUVtI3GcOk77OeLYjlMfnDT23RVRHm5EyCrjkptnvpD0wQScXePOFd2Xcw==}
-    dependencies:
-      '@walletconnect/modal-core': 2.6.1(react@18.2.0)
-      '@walletconnect/modal-ui': 2.6.1(react@18.2.0)
-    transitivePeerDependencies:
       - react
     dev: true
 
@@ -6823,7 +6572,6 @@ packages:
     resolution: {integrity: sha512-wwHYEIS0Q80f5mosx3L/dfG5t5rjEa9Ft51GTaNt862EnpyGHpgz2RkZvLPp1oF5TnAiTohkEKVEu8pQPJI7Vg==}
     dependencies:
       has-symbols: 1.0.3
-    dev: true
 
   /asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -6831,22 +6579,6 @@ packages:
   /atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
-
-  /autoprefixer@10.4.13(postcss@8.4.20):
-    resolution: {integrity: sha512-49vKpMqcZYsJjwotvt4+h/BCjJVnhGwcLpDt5xkcaOG3eLrG/HUYLagrihYsQ+qrIBgIzX1Rw7a6L8I/ZA1Atg==}
-    engines: {node: ^10 || ^12 || >=14}
-    hasBin: true
-    peerDependencies:
-      postcss: ^8.1.0
-    dependencies:
-      browserslist: 4.22.1
-      caniuse-lite: 1.0.30001554
-      fraction.js: 4.3.7
-      normalize-range: 0.1.2
-      picocolors: 1.0.0
-      postcss: 8.4.20
-      postcss-value-parser: 4.2.0
-    dev: true
 
   /autoprefixer@10.4.13(postcss@8.4.31):
     resolution: {integrity: sha512-49vKpMqcZYsJjwotvt4+h/BCjJVnhGwcLpDt5xkcaOG3eLrG/HUYLagrihYsQ+qrIBgIzX1Rw7a6L8I/ZA1Atg==}
@@ -6898,38 +6630,38 @@ packages:
     resolution: {integrity: sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw==}
     dev: true
 
-  /babel-plugin-polyfill-corejs2@0.4.6(@babel/core@7.22.10):
+  /babel-plugin-polyfill-corejs2@0.4.6(@babel/core@7.23.2):
     resolution: {integrity: sha512-jhHiWVZIlnPbEUKSSNb9YoWcQGdlTLq7z1GHL4AjFxaoOUMuuEVJ+Y4pAaQUGOGk93YsVCKPbqbfw3m0SM6H8Q==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
       '@babel/compat-data': 7.23.2
-      '@babel/core': 7.22.10
-      '@babel/helper-define-polyfill-provider': 0.4.3(@babel/core@7.22.10)
+      '@babel/core': 7.23.2
+      '@babel/helper-define-polyfill-provider': 0.4.3(@babel/core@7.23.2)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /babel-plugin-polyfill-corejs3@0.8.6(@babel/core@7.22.10):
+  /babel-plugin-polyfill-corejs3@0.8.6(@babel/core@7.23.2):
     resolution: {integrity: sha512-leDIc4l4tUgU7str5BWLS2h8q2N4Nf6lGZP6UrNDxdtfF2g69eJ5L0H7S8A5Ln/arfFAfHor5InAdZuIOwZdgQ==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.22.10
-      '@babel/helper-define-polyfill-provider': 0.4.3(@babel/core@7.22.10)
+      '@babel/core': 7.23.2
+      '@babel/helper-define-polyfill-provider': 0.4.3(@babel/core@7.23.2)
       core-js-compat: 3.33.1
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /babel-plugin-polyfill-regenerator@0.5.3(@babel/core@7.22.10):
+  /babel-plugin-polyfill-regenerator@0.5.3(@babel/core@7.23.2):
     resolution: {integrity: sha512-8sHeDOmXC8csczMrYEOf0UTNa4yE2SxV5JGeT/LP1n0OYVDUUFPxG9vdk2AlDlIit4t+Kf0xCtpgXPBwnn/9pw==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.22.10
-      '@babel/helper-define-polyfill-provider': 0.4.3(@babel/core@7.22.10)
+      '@babel/core': 7.23.2
+      '@babel/helper-define-polyfill-provider': 0.4.3(@babel/core@7.23.2)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -8119,7 +7851,6 @@ packages:
       internal-slot: 1.0.6
       iterator.prototype: 1.1.2
       safe-array-concat: 1.0.1
-    dev: true
 
   /es-set-tostringtag@2.0.2:
     resolution: {integrity: sha512-BuDyupZt65P9D2D2vA/zqcI3G5xRsklm5N3xCwuiy+/vKy8i0ifdsQP1sLgO4tZDSCaQUSnmC48khknGMV3D2Q==}
@@ -8247,7 +7978,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-config-next@13.4.13(eslint@8.47.0)(typescript@5.2.2):
+  /eslint-config-next@13.4.13(eslint@8.52.0)(typescript@5.2.2):
     resolution: {integrity: sha512-EXAh5h1yG/YTNa5YdskzaSZncBjKjvFe2zclMCi2KXyTsXha22wB6MPs/U7idB6a2qjpBdbZcruQY1TWjfNMZw==}
     peerDependencies:
       eslint: ^7.23.0 || ^8.0.0
@@ -8258,45 +7989,45 @@ packages:
     dependencies:
       '@next/eslint-plugin-next': 13.4.13
       '@rushstack/eslint-patch': 1.5.1
-      '@typescript-eslint/parser': 6.7.2(eslint@8.47.0)(typescript@5.2.2)
-      eslint: 8.47.0
+      '@typescript-eslint/parser': 6.7.2(eslint@8.52.0)(typescript@5.2.2)
+      eslint: 8.52.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.7.2)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.0)(eslint@8.47.0)
-      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@6.7.2)(eslint-import-resolver-typescript@3.6.1)(eslint@8.47.0)
-      eslint-plugin-jsx-a11y: 6.7.1(eslint@8.47.0)
-      eslint-plugin-react: 7.33.1(eslint@8.47.0)
-      eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.47.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.7.2)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.0)(eslint@8.52.0)
+      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@6.7.2)(eslint-import-resolver-typescript@3.6.1)(eslint@8.52.0)
+      eslint-plugin-jsx-a11y: 6.7.1(eslint@8.52.0)
+      eslint-plugin-react: 7.33.2(eslint@8.52.0)
+      eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.52.0)
       typescript: 5.2.2
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - supports-color
     dev: false
 
-  /eslint-config-prettier@9.0.0(eslint@8.47.0):
+  /eslint-config-prettier@9.0.0(eslint@8.52.0):
     resolution: {integrity: sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==}
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
     dependencies:
-      eslint: 8.47.0
+      eslint: 8.52.0
     dev: false
 
-  /eslint-config-turbo@1.10.12(eslint@8.47.0):
+  /eslint-config-turbo@1.10.12(eslint@8.52.0):
     resolution: {integrity: sha512-z3jfh+D7UGYlzMWGh+Kqz++hf8LOE96q3o5R8X4HTjmxaBWlLAWG+0Ounr38h+JLR2TJno0hU9zfzoPNkR9BdA==}
     peerDependencies:
       eslint: '>6.6.0'
     dependencies:
-      eslint: 8.47.0
-      eslint-plugin-turbo: 1.10.12(eslint@8.47.0)
+      eslint: 8.52.0
+      eslint-plugin-turbo: 1.10.12(eslint@8.52.0)
     dev: false
 
-  /eslint-filtered-fix@0.3.0(eslint@8.47.0):
+  /eslint-filtered-fix@0.3.0(eslint@8.52.0):
     resolution: {integrity: sha512-UMHOza9epEn9T+yVT8RiCFf0JdALpVzmoH62Ez/zvxM540IyUNAkr7aH2Frkv6zlm9a/gbmq/sc7C4SvzZQXcA==}
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
     dependencies:
-      eslint: 8.47.0
+      eslint: 8.52.0
       optionator: 0.9.3
     dev: false
 
@@ -8351,7 +8082,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.7.2)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.0)(eslint@8.47.0):
+  /eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.7.2)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.0)(eslint@8.52.0):
     resolution: {integrity: sha512-xgdptdoi5W3niYeuQxKmzVDTATvLYqhpwmykwsh7f6HIOStGWEIL9iqZgQDF9u9OEzrRwR8no5q2VT+bjAujTg==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -8360,9 +8091,9 @@ packages:
     dependencies:
       debug: 4.3.4(supports-color@5.5.0)
       enhanced-resolve: 5.15.0
-      eslint: 8.47.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.7.2)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.47.0)
-      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@6.7.2)(eslint-import-resolver-typescript@3.6.1)(eslint@8.47.0)
+      eslint: 8.52.0
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.7.2)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.52.0)
+      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@6.7.2)(eslint-import-resolver-typescript@3.6.1)(eslint@8.52.0)
       fast-glob: 3.3.1
       get-tsconfig: 4.7.2
       is-core-module: 2.13.1
@@ -8374,7 +8105,7 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-interactive@10.8.0(eslint@8.47.0):
+  /eslint-interactive@10.8.0(eslint@8.52.0):
     resolution: {integrity: sha512-bsMSr0NVyxoSbKbA3Rn8so5+A9q+Zu8xExiIM18umPjrqfBAN8WcJfsWvfc9Myfiqn2WwLDM9mRglbx+Hp+z3Q==}
     engines: {node: ^14.13.1 || >=16.0.0}
     hasBin: true
@@ -8385,7 +8116,7 @@ packages:
       chalk: 5.3.0
       comlink: 4.4.1
       enquirer: 2.4.1
-      eslint: 8.47.0
+      eslint: 8.52.0
       eslint-formatter-codeframe: 7.32.1
       estraverse: 5.3.0
       find-cache-dir: 4.0.0
@@ -8427,7 +8158,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils@2.8.0(@typescript-eslint/parser@6.7.2)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.47.0):
+  /eslint-module-utils@2.8.0(@typescript-eslint/parser@6.7.2)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.52.0):
     resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -8448,16 +8179,16 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.7.2(eslint@8.47.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 6.7.2(eslint@8.52.0)(typescript@5.2.2)
       debug: 3.2.7
-      eslint: 8.47.0
+      eslint: 8.52.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.7.2)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.0)(eslint@8.47.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.7.2)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.0)(eslint@8.52.0)
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /eslint-nibble@8.1.0(eslint@8.47.0):
+  /eslint-nibble@8.1.0(eslint@8.52.0):
     resolution: {integrity: sha512-x9H/1oeuKdC0HsaWeBarOryqNLC+7QZfAZIAP0HnGcmiiPktFIQq/D0e+iiCSyqYLSaui3UwvH56sXMrf5oQhw==}
     engines: {node: '>=12.0.0'}
     hasBin: true
@@ -8466,8 +8197,8 @@ packages:
     dependencies:
       '@ianvs/eslint-stats': 2.0.0
       chalk: 4.1.2
-      eslint: 8.47.0
-      eslint-filtered-fix: 0.3.0(eslint@8.47.0)
+      eslint: 8.52.0
+      eslint-filtered-fix: 0.3.0(eslint@8.52.0)
       eslint-formatter-friendly: 7.0.0
       eslint-summary: 1.0.0
       inquirer: 8.2.6
@@ -8509,7 +8240,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-import@2.29.0(@typescript-eslint/parser@6.7.2)(eslint-import-resolver-typescript@3.6.1)(eslint@8.47.0):
+  /eslint-plugin-import@2.29.0(@typescript-eslint/parser@6.7.2)(eslint-import-resolver-typescript@3.6.1)(eslint@8.52.0):
     resolution: {integrity: sha512-QPOO5NO6Odv5lpoTkddtutccQjysJuFxoPS7fAHO+9m9udNHvTCPSAMW9zGAYj8lAIdr40I8yPCdUYrncXtrwg==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -8519,16 +8250,16 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.7.2(eslint@8.47.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 6.7.2(eslint@8.52.0)(typescript@5.2.2)
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
       array.prototype.flat: 1.3.2
       array.prototype.flatmap: 1.3.2
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 8.47.0
+      eslint: 8.52.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.7.2)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.47.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.7.2)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.52.0)
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -8542,31 +8273,6 @@ packages:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
-    dev: false
-
-  /eslint-plugin-jsx-a11y@6.7.1(eslint@8.47.0):
-    resolution: {integrity: sha512-63Bog4iIethyo8smBklORknVjB0T2dwB8Mr/hIC+fBS0uyHdYYpzM/Ed+YC8VxTjlXHEWFOdmgwcDn1U2L9VCA==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
-    dependencies:
-      '@babel/runtime': 7.23.2
-      aria-query: 5.3.0
-      array-includes: 3.1.7
-      array.prototype.flatmap: 1.3.2
-      ast-types-flow: 0.0.7
-      axe-core: 4.8.2
-      axobject-query: 3.2.1
-      damerau-levenshtein: 1.0.8
-      emoji-regex: 9.2.2
-      eslint: 8.47.0
-      has: 1.0.4
-      jsx-ast-utils: 3.3.5
-      language-tags: 1.0.5
-      minimatch: 3.1.2
-      object.entries: 1.1.7
-      object.fromentries: 2.0.7
-      semver: 6.3.1
     dev: false
 
   /eslint-plugin-jsx-a11y@6.7.1(eslint@8.52.0):
@@ -8592,15 +8298,14 @@ packages:
       object.entries: 1.1.7
       object.fromentries: 2.0.7
       semver: 6.3.1
-    dev: true
 
-  /eslint-plugin-no-secrets@0.8.9(eslint@8.47.0):
+  /eslint-plugin-no-secrets@0.8.9(eslint@8.52.0):
     resolution: {integrity: sha512-CqaBxXrImABCtxMWspAnm8d5UKkpNylC7zqVveb+fJHEvsSiNGJlSWzdSIvBUnW1XhJXkzifNIZQC08rEII5Ng==}
     engines: {node: '>=10.0.0', npm: '>=6.9.0'}
     peerDependencies:
       eslint: '>=3.0.0'
     dependencies:
-      eslint: 8.47.0
+      eslint: 8.52.0
     dev: false
 
   /eslint-plugin-react-hooks@4.6.0(eslint@8.52.0):
@@ -8612,37 +8317,13 @@ packages:
       eslint: 8.52.0
     dev: true
 
-  /eslint-plugin-react-hooks@5.0.0-canary-7118f5dd7-20230705(eslint@8.47.0):
+  /eslint-plugin-react-hooks@5.0.0-canary-7118f5dd7-20230705(eslint@8.52.0):
     resolution: {integrity: sha512-AZYbMo/NW9chdL7vk6HQzQhT+PvTAEVqWk9ziruUoW2kAOcN5qNyelv70e0F1VNQAbvutOC9oc+xfWycI9FxDw==}
     engines: {node: '>=10'}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
     dependencies:
-      eslint: 8.47.0
-    dev: false
-
-  /eslint-plugin-react@7.33.1(eslint@8.47.0):
-    resolution: {integrity: sha512-L093k0WAMvr6VhNwReB8VgOq5s2LesZmrpPdKz/kZElQDzqS7G7+DnKoqT+w4JwuiGeAhAvHO0fvy0Eyk4ejDA==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
-    dependencies:
-      array-includes: 3.1.7
-      array.prototype.flatmap: 1.3.2
-      array.prototype.tosorted: 1.1.2
-      doctrine: 2.1.0
-      eslint: 8.47.0
-      estraverse: 5.3.0
-      jsx-ast-utils: 3.3.5
-      minimatch: 3.1.2
-      object.entries: 1.1.7
-      object.fromentries: 2.0.7
-      object.hasown: 1.1.3
-      object.values: 1.1.7
-      prop-types: 15.8.1
-      resolve: 2.0.0-next.5
-      semver: 6.3.1
-      string.prototype.matchall: 4.0.10
+      eslint: 8.52.0
     dev: false
 
   /eslint-plugin-react@7.33.2(eslint@8.52.0):
@@ -8668,27 +8349,26 @@ packages:
       resolve: 2.0.0-next.5
       semver: 6.3.1
       string.prototype.matchall: 4.0.10
-    dev: true
 
-  /eslint-plugin-sonarjs@0.20.0(eslint@8.47.0):
+  /eslint-plugin-sonarjs@0.20.0(eslint@8.52.0):
     resolution: {integrity: sha512-BRhZ7BY/oTr6DDaxvx58ReTg7R+J8T+Y2ZVGgShgpml25IHBTIG7EudUtHuJD1zhtMgUEt59x3VNvUQRo2LV6w==}
     engines: {node: '>=14'}
     peerDependencies:
       eslint: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      eslint: 8.47.0
+      eslint: 8.52.0
     dev: false
 
-  /eslint-plugin-turbo@1.10.12(eslint@8.47.0):
+  /eslint-plugin-turbo@1.10.12(eslint@8.52.0):
     resolution: {integrity: sha512-uNbdj+ohZaYo4tFJ6dStRXu2FZigwulR1b3URPXe0Q8YaE7thuekKNP+54CHtZPH9Zey9dmDx5btAQl9mfzGOw==}
     peerDependencies:
       eslint: '>6.6.0'
     dependencies:
       dotenv: 16.0.3
-      eslint: 8.47.0
+      eslint: 8.52.0
     dev: false
 
-  /eslint-plugin-vitest@0.2.8(eslint@8.47.0)(typescript@5.2.2)(vite@4.5.0)(vitest@0.34.1):
+  /eslint-plugin-vitest@0.2.8(eslint@8.52.0)(typescript@5.2.2)(vite@4.5.0)(vitest@0.34.1):
     resolution: {integrity: sha512-q8s4tStyKtn3gXf+8nf1ZYTHhoCXKdnozZzp6u8b4ni5v68Y4vxhNh4Z8njUfNjEY8HoPBB77MazHMR23IPb+g==}
     engines: {node: 14.x || >= 16}
     peerDependencies:
@@ -8699,8 +8379,8 @@ packages:
       vite:
         optional: true
     dependencies:
-      '@typescript-eslint/utils': 6.9.0(eslint@8.47.0)(typescript@5.2.2)
-      eslint: 8.47.0
+      '@typescript-eslint/utils': 6.9.0(eslint@8.52.0)(typescript@5.2.2)
+      eslint: 8.52.0
       vite: 4.5.0(@types/node@20.8.8)
       vitest: 0.34.1(jsdom@22.1.0)(playwright@1.39.0)
     transitivePeerDependencies:
@@ -8739,52 +8419,6 @@ packages:
   /eslint-visitor-keys@3.4.3:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-
-  /eslint@8.47.0:
-    resolution: {integrity: sha512-spUQWrdPt+pRVP1TTJLmfRNJJHHZryFmptzcafwSvHsceV81djHOdnEeDmkdotZyLNjDhrOasNK8nikkoG1O8Q==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    hasBin: true
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.47.0)
-      '@eslint-community/regexpp': 4.9.1
-      '@eslint/eslintrc': 2.1.2
-      '@eslint/js': 8.52.0
-      '@humanwhocodes/config-array': 0.11.13
-      '@humanwhocodes/module-importer': 1.0.1
-      '@nodelib/fs.walk': 1.2.8
-      ajv: 6.12.6
-      chalk: 4.1.2
-      cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@5.5.0)
-      doctrine: 3.0.0
-      escape-string-regexp: 4.0.0
-      eslint-scope: 7.2.2
-      eslint-visitor-keys: 3.4.3
-      espree: 9.6.1
-      esquery: 1.5.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 6.0.1
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      globals: 13.23.0
-      graphemer: 1.4.0
-      ignore: 5.2.4
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      is-path-inside: 3.0.3
-      js-yaml: 4.1.0
-      json-stable-stringify-without-jsonify: 1.0.1
-      levn: 0.4.1
-      lodash.merge: 4.6.2
-      minimatch: 3.1.2
-      natural-compare: 1.4.0
-      optionator: 0.9.3
-      strip-ansi: 6.0.1
-      text-table: 0.2.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   /eslint@8.52.0:
     resolution: {integrity: sha512-zh/JHnaixqHZsolRB/w9/02akBk9EPrOs9JwcTP2ek7yL5bVvXuRariiaAjjoJ5DvuwQ1WAE/HsMz+w17YgBCg==}
@@ -8831,7 +8465,6 @@ packages:
       text-table: 0.2.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /espree@9.6.1:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
@@ -9690,12 +9323,6 @@ packages:
     resolution: {integrity: sha512-VOPHhdDX0M/csRqEw+9Ectpf6wvTIg1MZDfAHxc3JKnAlJz7fcZSAKAeyDohOq0xuLx57esYpJopIvBaRb0Bag==}
     dev: true
 
-  /i18next@23.4.4:
-    resolution: {integrity: sha512-+c9B0txp/x1m5zn+QlwHaCS9vyFtmIAEXbVSFzwCX7vupm5V7va8F9cJGNJZ46X9ZtoGzhIiRC7eTIIh93TxPA==}
-    dependencies:
-      '@babel/runtime': 7.23.2
-    dev: true
-
   /i18next@23.6.0:
     resolution: {integrity: sha512-z0Cxr0MGkt+kli306WS4nNNM++9cgt2b2VCMprY92j+AIab/oclgPxdwtTZVLP1zn5t5uo8M6uLsZmYrcjr3HA==}
     dependencies:
@@ -9864,7 +9491,6 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       has-tostringtag: 1.0.0
-    dev: true
 
   /is-bigint@1.0.4:
     resolution: {integrity: sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==}
@@ -9912,7 +9538,6 @@ packages:
     resolution: {integrity: sha512-0by5vtUJs8iFQb5TYUHHPudOR+qXYIMKtiUzvLIZITZUjknFmziyBJuLhVRc+Ds0dREFlskDNJKYIdIzu/9pfw==}
     dependencies:
       call-bind: 1.0.5
-    dev: true
 
   /is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
@@ -9923,7 +9548,6 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       has-tostringtag: 1.0.0
-    dev: true
 
   /is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -10156,7 +9780,6 @@ packages:
       has-symbols: 1.0.3
       reflect.getprototypeof: 1.0.4
       set-function-name: 2.0.1
-    dev: true
 
   /jackspeak@2.3.6:
     resolution: {integrity: sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==}
@@ -10586,6 +10209,7 @@ packages:
       '@lit/reactive-element': 1.6.3
       lit-element: 3.3.3
       lit-html: 2.8.0
+    dev: false
 
   /lit@2.8.0:
     resolution: {integrity: sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==}
@@ -11344,26 +10968,6 @@ packages:
   /natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  /next-i18next@14.0.0(i18next@23.4.4)(next@13.5.5)(react-i18next@13.1.0)(react@18.2.0):
-    resolution: {integrity: sha512-umv8hOZoSoAA+td3ErfemyO/5Ib2pnYCdQ8/Oy+fncS2skFIL3hHKRer3Oa3Nfm4Xbv5p6DHWzm3NhT1j4tWwg==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      i18next: ^23.0.1
-      next: '>= 12.0.0'
-      react: '>= 17.0.2'
-      react-i18next: ^13.0.0
-    dependencies:
-      '@babel/runtime': 7.23.2
-      '@types/hoist-non-react-statics': 3.3.4
-      core-js: 3.33.1
-      hoist-non-react-statics: 3.3.2
-      i18next: 23.4.4
-      i18next-fs-backend: 2.2.0
-      next: 13.5.5(@babel/core@7.23.2)(react-dom@18.2.0)(react@18.2.0)
-      react: 18.2.0
-      react-i18next: 13.1.0(i18next@23.4.4)(react-dom@18.2.0)(react@18.2.0)
-    dev: true
-
   /next-i18next@14.0.0(i18next@23.6.0)(next@13.5.5)(react-i18next@13.3.1)(react@18.2.0):
     resolution: {integrity: sha512-umv8hOZoSoAA+td3ErfemyO/5Ib2pnYCdQ8/Oy+fncS2skFIL3hHKRer3Oa3Nfm4Xbv5p6DHWzm3NhT1j4tWwg==}
     engines: {node: '>=14'}
@@ -11427,45 +11031,6 @@ packages:
       '@next/swc-win32-arm64-msvc': 13.1.0
       '@next/swc-win32-ia32-msvc': 13.1.0
       '@next/swc-win32-x64-msvc': 13.1.0
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-    dev: false
-
-  /next@13.5.5(@babel/core@7.22.10)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-LddFJjpfrtrMMw8Q9VLhIURuSidiCNcMQjRqcPtrKd+Fx07MsG7hYndJb/f2d3I+mTbTotsTJfCnn0eZ/YPk8w==}
-    engines: {node: '>=16.14.0'}
-    hasBin: true
-    peerDependencies:
-      '@opentelemetry/api': ^1.1.0
-      react: ^18.2.0
-      react-dom: ^18.2.0
-      sass: ^1.3.0
-    peerDependenciesMeta:
-      '@opentelemetry/api':
-        optional: true
-      sass:
-        optional: true
-    dependencies:
-      '@next/env': 13.5.5
-      '@swc/helpers': 0.5.2
-      busboy: 1.6.0
-      caniuse-lite: 1.0.30001554
-      postcss: 8.4.31
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.1(@babel/core@7.22.10)(react@18.2.0)
-      watchpack: 2.4.0
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 13.5.5
-      '@next/swc-darwin-x64': 13.5.5
-      '@next/swc-linux-arm64-gnu': 13.5.5
-      '@next/swc-linux-arm64-musl': 13.5.5
-      '@next/swc-linux-x64-gnu': 13.5.5
-      '@next/swc-linux-x64-musl': 13.5.5
-      '@next/swc-win32-arm64-msvc': 13.5.5
-      '@next/swc-win32-ia32-msvc': 13.5.5
-      '@next/swc-win32-x64-msvc': 13.5.5
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -12045,23 +11610,6 @@ packages:
       camelcase-css: 2.0.1
       postcss: 8.4.31
 
-  /postcss-load-config@4.0.1(postcss@8.4.20):
-    resolution: {integrity: sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==}
-    engines: {node: '>= 14'}
-    peerDependencies:
-      postcss: '>=8.0.9'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      postcss:
-        optional: true
-      ts-node:
-        optional: true
-    dependencies:
-      lilconfig: 2.1.0
-      postcss: 8.4.20
-      yaml: 2.3.3
-    dev: true
-
   /postcss-load-config@4.0.1(postcss@8.4.31):
     resolution: {integrity: sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==}
     engines: {node: '>= 14'}
@@ -12105,15 +11653,6 @@ packages:
       picocolors: 1.0.0
       source-map-js: 1.0.2
     dev: false
-
-  /postcss@8.4.20:
-    resolution: {integrity: sha512-6Q04AXR1212bXr5fh03u8aAwbLxAQNGQ/Q1LNa0VfOI06ZAlhPHtQvE4OIdpj4kLThXilalPnmDSOD65DcHt+g==}
-    engines: {node: ^10 || ^12 || >=14}
-    dependencies:
-      nanoid: 3.3.6
-      picocolors: 1.0.0
-      source-map-js: 1.0.2
-    dev: true
 
   /postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
@@ -12420,26 +11959,6 @@ packages:
       react: 18.2.0
     dev: false
 
-  /react-i18next@13.1.0(i18next@23.4.4)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-TlDz4761vJe810o5nEzRkblfS0FQz+k9R5BLOPVhn0Ds6WMDcwGSMbU5fne9WSd4/vLgKg7fEJ7/JboWdmsHOw==}
-    peerDependencies:
-      i18next: '>= 23.2.3'
-      react: '>= 16.8.0'
-      react-dom: '*'
-      react-native: '*'
-    peerDependenciesMeta:
-      react-dom:
-        optional: true
-      react-native:
-        optional: true
-    dependencies:
-      '@babel/runtime': 7.23.2
-      html-parse-stringify: 3.0.1
-      i18next: 23.4.4
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    dev: true
-
   /react-i18next@13.3.1(i18next@23.6.0)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-JAtYREK879JXaN9GdzfBI4yJeo/XyLeXWUsRABvYXiFUakhZJ40l+kaTo+i+A/3cKIED41kS/HAbZ5BzFtq/Og==}
     peerDependencies:
@@ -12656,7 +12175,6 @@ packages:
       get-intrinsic: 1.2.2
       globalthis: 1.0.3
       which-builtin-type: 1.1.3
-    dev: true
 
   /regenerate-unicode-properties@10.1.1:
     resolution: {integrity: sha512-X007RyZLsCJVVrjgEFVpLUTZwyOZk3oiL75ZcuYjlIWd6rNJtOjkBwQc5AsRrpbKVkxN6sklw/k/9m2jJYOf8Q==}
@@ -13431,24 +12949,6 @@ packages:
       - '@babel/core'
     dev: false
 
-  /styled-jsx@5.1.1(@babel/core@7.22.10)(react@18.2.0):
-    resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
-    engines: {node: '>= 12.0.0'}
-    peerDependencies:
-      '@babel/core': '*'
-      babel-plugin-macros: '*'
-      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      babel-plugin-macros:
-        optional: true
-    dependencies:
-      '@babel/core': 7.22.10
-      client-only: 0.0.1
-      react: 18.2.0
-    dev: false
-
   /styled-jsx@5.1.1(@babel/core@7.23.2)(react@18.2.0):
     resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
     engines: {node: '>= 12.0.0'}
@@ -13552,37 +13052,6 @@ packages:
     resolution: {integrity: sha512-3mFKyCo/MBcgyOTlrY8T7odzZFx+w+qKSMAmdFzRvqBfLlSigU6TZnlFHK0lkMwj9Bj8OYU+9yW9lmGuS0QEnQ==}
     dev: false
 
-  /tailwindcss@3.3.3:
-    resolution: {integrity: sha512-A0KgSkef7eE4Mf+nKJ83i75TMyq8HqY3qmFIJSWy8bNt0v1lG7jUcpGpoTFxAwYcWOphcTBLPPJg+bDfhDf52w==}
-    engines: {node: '>=14.0.0'}
-    hasBin: true
-    dependencies:
-      '@alloc/quick-lru': 5.2.0
-      arg: 5.0.2
-      chokidar: 3.5.3
-      didyoumean: 1.2.2
-      dlv: 1.1.3
-      fast-glob: 3.3.1
-      glob-parent: 6.0.2
-      is-glob: 4.0.3
-      jiti: 1.20.0
-      lilconfig: 2.1.0
-      micromatch: 4.0.5
-      normalize-path: 3.0.0
-      object-hash: 3.0.0
-      picocolors: 1.0.0
-      postcss: 8.4.31
-      postcss-import: 15.1.0(postcss@8.4.31)
-      postcss-js: 4.0.1(postcss@8.4.31)
-      postcss-load-config: 4.0.1(postcss@8.4.31)
-      postcss-nested: 6.0.1(postcss@8.4.31)
-      postcss-selector-parser: 6.0.13
-      resolve: 1.22.8
-      sucrase: 3.34.0
-    transitivePeerDependencies:
-      - ts-node
-    dev: true
-
   /tailwindcss@3.3.4:
     resolution: {integrity: sha512-JXZNOkggUAc9T5E7nCrimoXHcSf9h3NWFe5sh36CGD/3M5TRLuQeFnQoDsit2uVTqgoOZHLx5rTykLUu16vsMQ==}
     engines: {node: '>=14.0.0'}
@@ -13612,7 +13081,6 @@ packages:
       sucrase: 3.34.0
     transitivePeerDependencies:
       - ts-node
-    dev: false
 
   /tapable@2.2.1:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
@@ -13901,43 +13369,6 @@ packages:
 
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
-
-  /tsup@7.2.0(postcss@8.4.20)(typescript@5.2.2):
-    resolution: {integrity: sha512-vDHlczXbgUvY3rWvqFEbSqmC1L7woozbzngMqTtL2PGBODTtWlRwGDDawhvWzr5c1QjKe4OAKqJGfE1xeXUvtQ==}
-    engines: {node: '>=16.14'}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': ^1
-      postcss: ^8.4.12
-      typescript: '>=4.1.0'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      postcss:
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      bundle-require: 4.0.2(esbuild@0.18.20)
-      cac: 6.7.14
-      chokidar: 3.5.3
-      debug: 4.3.4(supports-color@5.5.0)
-      esbuild: 0.18.20
-      execa: 5.1.1
-      globby: 11.1.0
-      joycon: 3.1.1
-      postcss: 8.4.20
-      postcss-load-config: 4.0.1(postcss@8.4.20)
-      resolve-from: 5.0.0
-      rollup: 3.29.4
-      source-map: 0.8.0-beta.0
-      sucrase: 3.34.0
-      tree-kill: 1.2.2
-      typescript: 5.2.2
-    transitivePeerDependencies:
-      - supports-color
-      - ts-node
-    dev: true
 
   /tsup@7.2.0(postcss@8.4.31)(typescript@5.2.2):
     resolution: {integrity: sha512-vDHlczXbgUvY3rWvqFEbSqmC1L7woozbzngMqTtL2PGBODTtWlRwGDDawhvWzr5c1QjKe4OAKqJGfE1xeXUvtQ==}
@@ -14373,6 +13804,7 @@ packages:
       proxy-compare: 2.5.1
       react: 18.2.0
       use-sync-external-store: 1.2.0(react@18.2.0)
+    dev: false
 
   /valtio@1.11.2(@types/react@18.2.21)(react@18.2.0):
     resolution: {integrity: sha512-1XfIxnUXzyswPAPXo1P3Pdx2mq/pIqZICkWN60Hby0d9Iqb+MEIpqgYVlbflvHdrp2YR/q3jyKWRPJJ100yxaw==}
@@ -14729,7 +14161,6 @@ packages:
       which-boxed-primitive: 1.0.2
       which-collection: 1.0.1
       which-typed-array: 1.1.13
-    dev: true
 
   /which-collection@1.0.1:
     resolution: {integrity: sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==}
@@ -14845,19 +14276,6 @@ packages:
       utf-8-validate:
         optional: true
     dev: true
-
-  /ws@8.14.2:
-    resolution: {integrity: sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-    dev: false
 
   /ws@8.14.2(bufferutil@4.0.8)(utf-8-validate@5.0.10):
     resolution: {integrity: sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==}
@@ -15015,9 +14433,9 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: true
 
-  github.com/chainapsis/keplr-chain-registry/2fe91c451ac09b86857d1ce5d60012232cedf4e6(@babel/core@7.23.2)(react-is@18.2.0):
-    resolution: {tarball: https://codeload.github.com/chainapsis/keplr-chain-registry/tar.gz/2fe91c451ac09b86857d1ce5d60012232cedf4e6}
-    id: github.com/chainapsis/keplr-chain-registry/2fe91c451ac09b86857d1ce5d60012232cedf4e6
+  github.com/chainapsis/keplr-chain-registry/7e580771af32f95c41f49b3596ce9da2a56b350a(@babel/core@7.23.2)(react-is@18.2.0):
+    resolution: {tarball: https://codeload.github.com/chainapsis/keplr-chain-registry/tar.gz/7e580771af32f95c41f49b3596ce9da2a56b350a}
+    id: github.com/chainapsis/keplr-chain-registry/7e580771af32f95c41f49b3596ce9da2a56b350a
     name: chainapsis-suggest-chain
     version: 0.0.1
     dependencies:
@@ -15045,8 +14463,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  github.com/evmos/chain-token-registry/2be54462eec4f6f9fb876c3caeca11f7e4d6d898:
-    resolution: {tarball: https://codeload.github.com/evmos/chain-token-registry/tar.gz/2be54462eec4f6f9fb876c3caeca11f7e4d6d898}
+  github.com/evmos/chain-token-registry/1045012f8213925dc05027f7aeab9f94700c4aa7:
+    resolution: {tarball: https://codeload.github.com/evmos/chain-token-registry/tar.gz/1045012f8213925dc05027f7aeab9f94700c4aa7}
     name: chain-token-registry#main
     version: 0.0.0
     dev: true


### PR DESCRIPTION
# 🧙 Description

This PR solves two things
1 - update dappwright package and adapt a few things to it because it uses a newer version of metamask
2 - reduce flakiness of some tests caused by race conditions in the usage of the `waitForEvent('page')` method



Ticket #

## ✅ Checklist

- [x] Acceptance Criteria described in the ticket are met
- [ ] Texts and strings are in the related i18n file
- [x] Utilities have unit tests
- [ ] User stories and functionalities have integration or e2e tests
- [ ] Related packages.json are upgraded
- [ ] Changelog is updated
