### PR TITLE
fix: hardcode estimation for ics transfers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+- (fix) | packages/evmos-wallet 1.0.22 | hardcode estimation for ics transfers while core team fixes the issue with precompile gas estimation
 - (chore) fse-794 | apps/mission 1.0.26 apps/assets 1.0.35 packages/stateful-components 1.0.3 | Update redirects: replace assets with portfolio
 
 ## 1.3.7 - 2023-10-31

--- a/packages/evmos-wallet/package.json
+++ b/packages/evmos-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evmos-wallet",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "main": "./src/index.tsx",
   "types": "./src/index.tsx",
   "type": "module",

--- a/packages/evmos-wallet/src/registry-actions/transfers/prepare-contract-ibc-transfer.ts
+++ b/packages/evmos-wallet/src/registry-actions/transfers/prepare-contract-ibc-transfer.ts
@@ -11,7 +11,6 @@ import { Prefix, TokenAmount } from "../types";
 import { getIBCChannelId, getTimeoutTimestamp } from "../utils";
 import { writeContract } from "wagmi/actions";
 import { getIBCDenom } from "../utils/get-ibc-denom";
-import { buffGasEstimate } from "../utils/buff-gas-estimate";
 import { getTokenByRef } from "../get-token-by-ref";
 
 export const prepareContractIBCTransfer = async <T extends Prefix>({
@@ -58,9 +57,14 @@ export const prepareContractIBCTransfer = async <T extends Prefix>({
       "",
     ],
   } as const;
-  const estimatedGas = buffGasEstimate(
-    await evmosClient.estimateContractGas(args)
-  );
+  // TODO: Hardcoding gas estimation for now due to a bug in core
+  // uncomment this when the bug is fixed
+  // https://linear.app/altiplanic/issue/FSE-835/hardcode-gas-estimation-value
+  //
+  // const estimatedGas = buffGasEstimate(
+  //   await evmosClient.estimateContractGas(args)
+  // );
+  const estimatedGas = 72000n;
 
   const { request } = await evmosClient.simulateContract({
     ...args,


### PR DESCRIPTION
# 🧙 Description


Simulated estimations are wrong so we're hardcoding gas limit for now

Example transaction that's failed: https://escan.live/address/0x0000000000000000000000000000000000000802

This is due to a bug on gas estimations in core

Follow discussion here: 

https://altiplanic.slack.com/archives/C0541U45A1K/p1698861111074019

The long fix will come with the fix from Core (see ticket from our side here [FSE-797](https://linear.app/altiplanic/issue/FSE-797/convert-button-not-working-for-mm-fine-with-keplr))

Ticket FSE-835

## ✅ Checklist

- [ ] Acceptance Criteria described in the ticket are met
- [ ] Texts and strings are in the related i18n file
- [ ] Utilities have unit tests
- [ ] User stories and functionalities have integration or e2e tests
- [ ] Related packages.json are upgraded
- [ ] Changelog is updated
