### PR TITLE
chore: Fix Safe WEVMOS unwrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+- (chore) fse-864 | packages/evmos-wallet 1.0.24 | remove prepareTransaction for unwrapping wevmos
 - (chore) fse-846 | apps/assets 1.0.40 apps/mission 1.0.27 packages/constants-helper 1.0.10 packages/tracker 1.0.9 packages/ui-helpers 1.0.20 | Get rid of broken links and create a reusable link component
 - (chore) fse-819 | packages/constants-helper 1.0.9 packages/icons 1.0.11 packages/ui-helpers 1.0.19 | Add medium to footer
 - (fix) fse-802 | packages/ui-helpers 1.0.18 | Center text in staking app

--- a/apps/assets/src/components/asset/modals/transactions/contracts/hooks/useWEVMOS.ts
+++ b/apps/assets/src/components/asset/modals/transactions/contracts/hooks/useWEVMOS.ts
@@ -1,7 +1,6 @@
 import WETH_ABI from "../../contracts/abis/WEVMOS/WEVMOS.json";
 import { WEVMOS_CONTRACT_ADDRESS } from "../../../constants";
 import {
-  prepareSendTransaction,
   prepareWriteContract,
   sendTransaction,
   writeContract,
@@ -23,7 +22,7 @@ export function useWEVMOS() {
   }
 
   async function withdraw(amount: BigNumber, hexAddress: string) {
-    const req = await prepareSendTransaction({
+    return await sendTransaction({
       to: WEVMOS_CONTRACT_ADDRESS,
       account: hexAddress as `0x${string}`,
       value: 0n,
@@ -33,7 +32,6 @@ export function useWEVMOS() {
         args: [amount.toBigInt()],
       }),
     });
-    return await sendTransaction(req);
   }
 
   return {

--- a/packages/evmos-wallet/package.json
+++ b/packages/evmos-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evmos-wallet",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "main": "./src/index.tsx",
   "types": "./src/index.tsx",
   "type": "module",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,7 +152,7 @@ importers:
         version: 2.47.1
       chainapsis-suggest-chain:
         specifier: github:chainapsis/keplr-chain-registry
-        version: github.com/chainapsis/keplr-chain-registry/4c25cbdacb5b5126324a1d4a221f7a7f785b6838(@babel/core@7.23.2)(react-is@18.2.0)
+        version: github.com/chainapsis/keplr-chain-registry/b2a604eeaaf3cc8cc89fdbca019793f2d5b32370(@babel/core@7.23.2)(react-is@18.2.0)
       dotenv:
         specifier: ^16.3.1
         version: 16.3.1
@@ -1281,7 +1281,7 @@ importers:
         version: 8.12.0
       chain-token-registry:
         specifier: github:evmos/chain-token-registry#main
-        version: github.com/evmos/chain-token-registry/1045012f8213925dc05027f7aeab9f94700c4aa7
+        version: github.com/evmos/chain-token-registry/7f1a4a3c1c0a00bee30929dfaa13a9fd23128d39
       chalk:
         specifier: ^5.3.0
         version: 5.3.0
@@ -14390,9 +14390,9 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: true
 
-  github.com/chainapsis/keplr-chain-registry/4c25cbdacb5b5126324a1d4a221f7a7f785b6838(@babel/core@7.23.2)(react-is@18.2.0):
-    resolution: {tarball: https://codeload.github.com/chainapsis/keplr-chain-registry/tar.gz/4c25cbdacb5b5126324a1d4a221f7a7f785b6838}
-    id: github.com/chainapsis/keplr-chain-registry/4c25cbdacb5b5126324a1d4a221f7a7f785b6838
+  github.com/chainapsis/keplr-chain-registry/b2a604eeaaf3cc8cc89fdbca019793f2d5b32370(@babel/core@7.23.2)(react-is@18.2.0):
+    resolution: {tarball: https://codeload.github.com/chainapsis/keplr-chain-registry/tar.gz/b2a604eeaaf3cc8cc89fdbca019793f2d5b32370}
+    id: github.com/chainapsis/keplr-chain-registry/b2a604eeaaf3cc8cc89fdbca019793f2d5b32370
     name: chainapsis-suggest-chain
     version: 0.0.1
     dependencies:
@@ -14420,8 +14420,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  github.com/evmos/chain-token-registry/1045012f8213925dc05027f7aeab9f94700c4aa7:
-    resolution: {tarball: https://codeload.github.com/evmos/chain-token-registry/tar.gz/1045012f8213925dc05027f7aeab9f94700c4aa7}
+  github.com/evmos/chain-token-registry/7f1a4a3c1c0a00bee30929dfaa13a9fd23128d39:
+    resolution: {tarball: https://codeload.github.com/evmos/chain-token-registry/tar.gz/7f1a4a3c1c0a00bee30929dfaa13a9fd23128d39}
     name: chain-token-registry#main
     version: 0.0.0
     dev: true


### PR DESCRIPTION
# 🧙 Description

The `wagmi` prepareTransaction function seems not to be compatible with safe.

This PR removes the prepareTransaction step for unwrapping WEVMOS and directly executes the sendTransaction function call which seems to be compatible with safe