### PR TITLE
Release v1.3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+## 1.3.9 - 2023-11-14
+
 - (chore) fse-815 | apps/assets 1.0.41 packages/evmos-wallet 1.0.24 packages/registry 1.0.4 | Enable Kujira network
 - (chore) fse-864 | packages/evmos-wallet 1.0.24 | remove prepareTransaction for unwrapping wevmos
 - (chore) fse-846 | apps/assets 1.0.40 apps/mission 1.0.27 packages/constants-helper 1.0.10 packages/tracker 1.0.9 packages/ui-helpers 1.0.20 | Get rid of broken links and create a reusable link component

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evmos-apps",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "license": "SEE LICENSE IN LICENSE",
   "author": "Tharsis Labs Ltd.(Evmos)",
   "private": true,


### PR DESCRIPTION
## 1.3.9 - 2023-11-14

- (chore) fse-815 | apps/assets 1.0.41 packages/evmos-wallet 1.0.24 packages/registry 1.0.4 | Enable Kujira network
- (chore) fse-864 | packages/evmos-wallet 1.0.24 | remove prepareTransaction for unwrapping wevmos
- (chore) fse-846 | apps/assets 1.0.40 apps/mission 1.0.27 packages/constants-helper 1.0.10 packages/tracker 1.0.9 packages/ui-helpers 1.0.20 | Get rid of broken links and create a reusable link component
- (chore) fse-819 | packages/constants-helper 1.0.9 packages/icons 1.0.11 packages/ui-helpers 1.0.19 | Add medium to footer
- (fix) fse-802 | packages/ui-helpers 1.0.18 | Center text in staking app
- (chore) fse-799 | packages/copilot 1.0.10 | Use wagmi value instead of redux value
- (fix) fse-816 | packages/ui-helpers 1.0.17 packages/icons 1.0.10 | Replace Twitter logo to X logo in the footer
- (fix) fse-831 | apps/assets 1.0.39 | Fix usdc.grv image
- (fix) fse-837 | apps/vesting 1.1.4 | Fix error in account details page for vesting
- (fix) fse-836 | apps/vesting 1.1.3 | Fix error on creating vesting account
- (fix) fse-834 | apps/assets 1.0.38 | Fix error generating txns appear twice in pay modal
- (fix) fse-800 | apps/assets 1.0.37 apps/governance 1.0.28 apps/staking 1.1.2 apps/vesting 1.1.2 packages/evmos-wallet 1.0.23 | Suggest changing network to evmos (MetaMask)
