### PR TITLE
fix: redirect on breadcrumbs

### DIFF
--- a/pages/dappstore/src/pages/dapp-explorer/partials/explorer-breadcrumbs.tsx
+++ b/pages/dappstore/src/pages/dapp-explorer/partials/explorer-breadcrumbs.tsx
@@ -10,7 +10,7 @@ export const ExplorerBreadcrumbs = async ({
   const pages = [
     {
       name: "dApp Store",
-      href: "/",
+      href: "/dapps",
     },
   ];
   const { categories, dApps } = await fetchExplorerData();


### PR DESCRIPTION
# 🧙 Description

redirect to /dapps when user clicks on dappstore (breadcrumbs)

Ticket #fse-866

## ✅ Checklist

- [ ] Acceptance Criteria described in the ticket are met
- [ ] Texts and strings are in the related i18n file
- [ ] Utilities have unit tests
- [ ] User stories and functionalities have integration or e2e tests
- [ ] If adding a new token or network
  - [ ] Registry package is updated
  - [ ] Asset images are added
- [ ] Related packages.json are upgraded
- [ ] Changelog is updated
