### PR TITLE
fixes: bug from deploy preview

### DIFF
--- a/apps/mission/src/components/header/Header.tsx
+++ b/apps/mission/src/components/header/Header.tsx
@@ -4,13 +4,11 @@ import { LaunchPad } from "./LaunchPad";
 import { WalletButton } from "./WalletButton";
 import { Container } from "@evmosapps/ui-helpers";
 import { EvmosPrice } from "./TokenPrice";
-import { Suspense } from "react";
-
 export const Header = () => {
   return (
     <Container
       full
-      className="flex flex-col text-pearl md:flex-row md:items-center md:justify-between my-5 md:my-16 items-center gap-y-6"
+      className="flex flex-col text-pearl md:flex-row md:items-center md:justify-between my-5 md:my-10 items-center gap-y-6 px-0  sm:px-5 xl:px-14"
     >
       <Branding />
 

--- a/apps/mission/src/components/header/LaunchPad.tsx
+++ b/apps/mission/src/components/header/LaunchPad.tsx
@@ -109,7 +109,6 @@ export function LaunchPad({}: { showPing?: boolean }) {
               });
             }}
             href="/dapps"
-            target="_blank"
             rel="noopener noreferrer"
             className="border-t-darkGray700 text-pearl bg-darkGray2Opacity active:bg-darkGray700 flex justify-center border-t py-5 transition-all duration-200 ease-in-out hover:bg-[#FFFFFF0F]"
           >

--- a/packages/constants-helper/src/constants.ts
+++ b/packages/constants-helper/src/constants.ts
@@ -25,7 +25,8 @@ export const GOOGLE_FORM_URL =
 export const FEEDBACK_URL = "https://evmos.canny.io/feedback";
 export const DOCS_SMART_CONTRACTS_URL =
   "https://docs.evmos.org/develop/smart-contracts";
-export const DOCS_EVMOS = "https://docs.evmos.org/develop";
+export const DOCS_EVMOS_REVENUE =
+  "https://docs.evmos.org/protocol/modules/revenue#abstract";
 export const ADD_DAPP_FORM_URL = "https://tally.so/r/wbWjlL";
 export const STRIDE_URL = "https://app.stride.zone/?chain=EVMOS";
 export const FORGE_URL = "https://forge.trade/";

--- a/packages/constants-helper/src/index.ts
+++ b/packages/constants-helper/src/index.ts
@@ -30,5 +30,5 @@ export { KEPLR_DOWNLOAD_URL } from "./constants";
 export { ICONS_TYPES } from "./constants";
 export { EMOJIS } from "./constants";
 export { EXPLORER_URL } from "./constants";
-export { DOCS_EVMOS } from "./constants";
+export { DOCS_EVMOS_REVENUE } from "./constants";
 export { ADD_DAPP_FORM_URL } from "./constants";

--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -18,7 +18,7 @@
   },
   "launchPad": {
     "dApp": {
-      "title": "dApp Store"
+      "title": "Home"
     },
     "assets": {
       "title": "Portfolio"

--- a/packages/i18n/locales/en/copilot-setup-account.json
+++ b/packages/i18n/locales/en/copilot-setup-account.json
@@ -1,7 +1,7 @@
 {
   "setupHeaderSteps": {
-    "setup": "Setup up your account",
-    "topup": "Topup your account",
+    "setup": "Set up your account",
+    "topup": "Top up your account",
     "nextsteps": "Next steps"
   },
 

--- a/packages/i18n/locales/en/dappStore.json
+++ b/packages/i18n/locales/en/dappStore.json
@@ -49,7 +49,7 @@
     "title2": "to the dapp Store",
     "description": "Interested in adding your dApp to our dApp Store and earning revenue?",
     "addAppButton": "Add your dApp",
-    "learnButton": "Learn to build on Evmos",
+    "revenueButton": "Earn revenue on Evmos",
     "button": {
       "text": "See all",
       "text2": "dApps"

--- a/packages/ui-helpers/src/launchPad/Container.tsx
+++ b/packages/ui-helpers/src/launchPad/Container.tsx
@@ -73,7 +73,6 @@ export const LaunchContainer = ({
           <Link
             onClick={handleEcosystemButton}
             href="/dapps"
-            target="_blank"
             rel="noopener noreferrer"
             className="border-t-darkGray700 text-pearl bg-darkGray2Opacity active:bg-darkGray700 flex justify-center border-t py-5 transition-all duration-200 ease-in-out hover:bg-[#FFFFFF0F]"
           >

--- a/pages/dappstore/src/pages/dapp-explorer/dapp-explorer-page.tsx
+++ b/pages/dappstore/src/pages/dapp-explorer/dapp-explorer-page.tsx
@@ -72,7 +72,7 @@ export const DappExplorerPage = async ({
         params={params}
       />
 
-      <EcosystemCardGrid className="mt-20">
+      <EcosystemCardGrid className="pt-8">
         {sortedApps?.map((dApp) => (
           <EcosystemCard data={dApp} key={dApp.name} />
         ))}

--- a/pages/dappstore/src/pages/dapp-explorer/partials/header-categories.tsx
+++ b/pages/dappstore/src/pages/dapp-explorer/partials/header-categories.tsx
@@ -92,7 +92,7 @@ const CategoryHeader = ({
   const categoryName = category?.name ?? "dApps";
 
   return (
-    <div {...rest}>
+    <div className="space-y-3" {...rest}>
       <Title>
         <Trans
           shouldUnescape={true}

--- a/pages/dappstore/src/pages/landing/partials/ecosystem-card.tsx
+++ b/pages/dappstore/src/pages/landing/partials/ecosystem-card.tsx
@@ -43,14 +43,14 @@ export const EcosystemCard = ({ data }: { data: DApp }) => {
           )}
         </div>
         <div className="flex space-x-3 items-center px-5 pt-5">
-          <h3 className="text-sm font-bold text-pearl">{data.name}</h3>
+          <h3 className="font-bold text-pearl">{data.name}</h3>
           {data.instantDapp ? (
             <Badge className="text-sm gap-x-2 whitespace-nowrap overflow-hidden">
               {/* TODO: check if we need to create a component for this */}
               {/* TODO: add color to tailwind file */}
               <span className="w-[8px] h-[8px] aspect-square bg-[#AE00FF] rounded-full" />
               <span className="overflow-ellipsis overflow-hidden">
-                Instant dApp{" "}
+                Instant dApp
               </span>
             </Badge>
           ) : (

--- a/pages/dappstore/src/pages/landing/partials/ecosystem-section.tsx
+++ b/pages/dappstore/src/pages/landing/partials/ecosystem-section.tsx
@@ -10,10 +10,30 @@ import { ButtonWithLink } from "@evmosapps/ui-helpers";
 import { fetchExplorerData } from "../../../lib/fetch-explorer-data";
 import { EcosystemCardGrid } from "./ecosystem-card-grid";
 
+const landingdAppsOrder = [
+  "stride",
+  "forge",
+  "squid",
+  "wormhole",
+  "layerswap",
+  "cypher-wallet",
+  "transak",
+  "c14",
+];
 export const EcosystemSection = async () => {
   const { t } = await translation("dappStore");
   const { dApps } = await fetchExplorerData();
-  const instantDapps = dApps.filter((dApp) => dApp.instantDapp);
+
+  const instantDapps = dApps
+    // get the instant dapps
+    .filter((dApp) => dApp.instantDapp)
+    // sort them by the order in the array
+    .sort((a, b) => {
+      return (
+        landingdAppsOrder.indexOf(a.slug) - landingdAppsOrder.indexOf(b.slug)
+      );
+    });
+
   return (
     <section className="space-y-8">
       <div className="space-y-2">

--- a/pages/dappstore/src/pages/landing/partials/hero-section.tsx
+++ b/pages/dappstore/src/pages/landing/partials/hero-section.tsx
@@ -1,7 +1,7 @@
 // Copyright Tharsis Labs Ltd.(Evmos)
 // SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
 
-import { ADD_DAPP_FORM_URL } from "constants-helper";
+import { ADD_DAPP_FORM_URL, DOCS_EVMOS_REVENUE } from "constants-helper";
 import Image from "next/image";
 import { Frameline, PrimaryButton } from "@evmosapps/ui-helpers";
 import { translation } from "@evmosapps/i18n/server";
@@ -40,11 +40,11 @@ export const HeroSection = async () => {
             as={"a"}
             className="flex-1 font-normal rounded w-full"
             variant="secondary"
-            href="/docs"
+            href={DOCS_EVMOS_REVENUE}
             target="_blank"
             referrerPolicy="no-referrer"
           >
-            {t("ecosystem.learnButton")}
+            {t("ecosystem.revenueButton")}
           </PrimaryButton>
         </div>
       </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,7 +155,7 @@ importers:
         version: 2.47.0
       next:
         specifier: 14.0.3
-        version: 14.0.3(react-dom@18.2.0)(react@18.2.0)
+        version: 14.0.3(@babel/core@7.23.3)(react-dom@18.2.0)(react@18.2.0)
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -6160,7 +6160,7 @@ packages:
       react-dom: ^18.0.0
     dependencies:
       '@tanstack/react-query': 5.8.4(react-dom@18.2.0)(react@18.2.0)
-      next: 14.0.3(react-dom@18.2.0)(react@18.2.0)
+      next: 14.0.3(@babel/core@7.23.3)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
@@ -6535,6 +6535,7 @@ packages:
 
   /@types/node@20.4.1:
     resolution: {integrity: sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg==}
+    dev: true
 
   /@types/node@20.9.2:
     resolution: {integrity: sha512-WHZXKFCEyIUJzAwh3NyyTHYSR35SevJ6mZ1nWwJafKtiQbqRTIKSRcw3Ma3acqgsent3RRDqeVwpHntMk+9irg==}
@@ -8852,17 +8853,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.3
-
-  /debug@4.3.4:
-    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.1.2
 
   /debug@4.3.4(supports-color@5.5.0):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -11189,7 +11179,7 @@ packages:
     dependencies:
       '@ioredis/commands': 1.2.0
       cluster-key-slot: 1.1.2
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@5.5.0)
       denque: 2.1.0
       lodash.defaults: 4.2.0
       lodash.isarguments: 3.1.0
@@ -11581,7 +11571,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 20.4.1
+      '@types/node': 20.9.2
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: false
@@ -12763,7 +12753,7 @@ packages:
     resolution: {integrity: sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==}
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@5.5.0)
       decode-named-character-reference: 1.0.2
       micromark-core-commonmark: 1.1.0
       micromark-factory-space: 1.1.0
@@ -13007,7 +12997,7 @@ packages:
       hoist-non-react-statics: 3.3.2
       i18next: 23.7.6
       i18next-fs-backend: 2.3.0
-      next: 14.0.3(react-dom@18.2.0)(react@18.2.0)
+      next: 14.0.3(@babel/core@7.23.3)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-i18next: 13.5.0(i18next@23.7.6)(react-dom@18.2.0)(react@18.2.0)
     dev: true
@@ -13083,45 +13073,6 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       styled-jsx: 5.1.1(@babel/core@7.23.3)(react@18.2.0)
-      watchpack: 2.4.0
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 14.0.3
-      '@next/swc-darwin-x64': 14.0.3
-      '@next/swc-linux-arm64-gnu': 14.0.3
-      '@next/swc-linux-arm64-musl': 14.0.3
-      '@next/swc-linux-x64-gnu': 14.0.3
-      '@next/swc-linux-x64-musl': 14.0.3
-      '@next/swc-win32-arm64-msvc': 14.0.3
-      '@next/swc-win32-ia32-msvc': 14.0.3
-      '@next/swc-win32-x64-msvc': 14.0.3
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-    dev: false
-
-  /next@14.0.3(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-AbYdRNfImBr3XGtvnwOxq8ekVCwbFTv/UJoLwmaX89nk9i051AEY4/HAWzU0YpaTDw8IofUpmuIlvzWF13jxIw==}
-    engines: {node: '>=18.17.0'}
-    hasBin: true
-    peerDependencies:
-      '@opentelemetry/api': ^1.1.0
-      react: ^18.2.0
-      react-dom: ^18.2.0
-      sass: ^1.3.0
-    peerDependenciesMeta:
-      '@opentelemetry/api':
-        optional: true
-      sass:
-        optional: true
-    dependencies:
-      '@next/env': 14.0.3
-      '@swc/helpers': 0.5.2
-      busboy: 1.6.0
-      caniuse-lite: 1.0.30001563
-      postcss: 8.4.31
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.1(react@18.2.0)
       watchpack: 2.4.0
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.0.3
@@ -15453,22 +15404,6 @@ packages:
         optional: true
     dependencies:
       '@babel/core': 7.23.3
-      client-only: 0.0.1
-      react: 18.2.0
-
-  /styled-jsx@5.1.1(react@18.2.0):
-    resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
-    engines: {node: '>= 12.0.0'}
-    peerDependencies:
-      '@babel/core': '*'
-      babel-plugin-macros: '*'
-      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      babel-plugin-macros:
-        optional: true
-    dependencies:
       client-only: 0.0.1
       react: 18.2.0
 


### PR DESCRIPTION
# 🧙 Description

Fixes: bug from deploy preview
- Styles
- "View all dApps" in the nav bar / app launcher should NOT lead to a new tab, it should update the page the user is on already
- Fix: 
   - "Setup up your account" to "Set up your account"
   - "Topup your account" to "Top up your account"
- Link leads to: https://deploy-preview-689--evmos-mission.netlify.app/docs, 404 error, maybe this wasn't intended
- Sort Instant dApps in home page according to the order listed in [FSE-852](https://linear.app/altiplanic/issue/FSE-852/page-1-home-page) (see Acceptance Criteria)
- rename to "Home"
- font size of the dApp name could be a bit bigger, without making changes to the font size for "Instant dApp"

Ticket #fse-877

## ✅ Checklist

- [ ] Acceptance Criteria described in the ticket are met
- [ ] Texts and strings are in the related i18n file
- [ ] Utilities have unit tests
- [ ] User stories and functionalities have integration or e2e tests
- [ ] If adding a new token or network
  - [ ] Registry package is updated
  - [ ] Asset images are added
- [ ] Related packages.json are upgraded
- [ ] Changelog is updated
