### PR TITLE
fix: copilot card buttons

### DIFF
--- a/pages/dappstore/src/pages/landing/partials/copilot-card/copilot-card.tsx
+++ b/pages/dappstore/src/pages/landing/partials/copilot-card/copilot-card.tsx
@@ -6,7 +6,7 @@ import { cn } from "helpers";
 import { ComponentProps } from "react";
 import { SetupAccountModalTrigger } from "stateful-components/src/modals/SetupAccountModal/SetupAccountModal";
 import { Link, useTranslation } from "@evmosapps/i18n/client";
-import { CLICK_ON_COPILOT_BANNER } from "tracker";
+import { CLICK_ON_COPILOT_BANNER, sendEvent } from "tracker";
 import { Frameline } from "@evmosapps/ui-helpers/src/container/FrameLine";
 import { TrackerEvent } from "@evmosapps/ui-helpers/src/TrackerEvent";
 export const CopilotCard = () => {
@@ -78,16 +78,16 @@ export const CopilotCard = () => {
         {setupAccountActive && (
           <Frameline className="w-full p-2">
             <SetupAccountModalTrigger>
-              <TrackerEvent
-                event={CLICK_ON_COPILOT_BANNER}
-                properties={{
-                  "Copilot Actions": "Let's go",
+              <button
+                onClick={() => {
+                  sendEvent(CLICK_ON_COPILOT_BANNER, {
+                    "Copilot Actions": "Let's go",
+                  });
                 }}
+                className={`${linkCn} bg-red-300`}
               >
-                <button className={`${linkCn} bg-red-300`}>
-                  {t("copilotCard.letsGo")}
-                </button>
-              </TrackerEvent>
+                {t("copilotCard.letsGo")}
+              </button>
             </SetupAccountModalTrigger>
           </Frameline>
         )}
@@ -98,14 +98,16 @@ export const CopilotCard = () => {
                 step: "intro-topup",
               }}
             >
-              <TrackerEvent
-                event={CLICK_ON_COPILOT_BANNER}
-                properties={{
-                  "Copilot Actions": "Top up account",
+              <button
+                onClick={() => {
+                  sendEvent(CLICK_ON_COPILOT_BANNER, {
+                    "Copilot Actions": "Top up account",
+                  });
                 }}
+                className={linkCn}
               >
-                <button className={linkCn}>{t("copilotCard.topUp")}</button>
-              </TrackerEvent>
+                {t("copilotCard.topUp")}
+              </button>
             </SetupAccountModalTrigger>
           </Frameline>
         )}


### PR DESCRIPTION
# 🧙 Description

The let's go and top-up buttons inside copilot card weren't working. 
We'll use sendEvent instead of TrackerEvent. With that change the modal appears and the event is tracked. 

Ticket #

## ✅ Checklist

- [ ] Acceptance Criteria described in the ticket are met
- [ ] Texts and strings are in the related i18n file
- [ ] Utilities have unit tests
- [ ] User stories and functionalities have integration or e2e tests
- [ ] If adding a new token or network
  - [ ] Registry package is updated
  - [ ] Asset images are added
- [ ] Related packages.json are upgraded
- [ ] Changelog is updated
