### PR TITLE
fix: show value instead of NaN on osmosis. Update colors

### DIFF
--- a/packages/instant-dapps/src/dapps/Osmosis.tsx
+++ b/packages/instant-dapps/src/dapps/Osmosis.tsx
@@ -14,8 +14,8 @@ export default function OsmosisInstantDapp() {
   if (isDisconnected) {
     return (
       <ConnectionRequired
-        bgUrl="bg-[url(/ecosystem/blur/cypher-blur.png)]"
-        dappName="Cypher Wallet"
+        bgUrl="bg-[url(/ecosystem/blur/osmosis-blur.png)]"
+        dappName="Osmosis"
       >
         <ConnectButton />
       </ConnectionRequired>

--- a/packages/instant-dapps/src/dapps/Stride.tsx
+++ b/packages/instant-dapps/src/dapps/Stride.tsx
@@ -12,8 +12,8 @@ export default function StrideInstantDapp() {
   if (isDisconnected) {
     return (
       <ConnectionRequired
-        bgUrl="bg-[url(/ecosystem/blur/cypher-blur.png)]"
-        dappName="Cypher Wallet"
+        bgUrl="bg-[url(/ecosystem/blur/stride-blur.png)]"
+        dappName="Stride"
       >
         <ConnectButton />
       </ConnectionRequired>


### PR DESCRIPTION
# 🧙 Description

Show value instead of NaN on osmosis. 
Update colors
Add pulse animation for images when tokenIdentifier is not set.

Ticket #fse-915 and #fse-916

## ✅ Checklist

- [ ] Acceptance Criteria described in the ticket are met
- [ ] Texts and strings are in the related i18n file
- [ ] Utilities have unit tests
- [ ] User stories and functionalities have integration or e2e tests
- [ ] If adding a new token or network
  - [ ] Registry package is updated
  - [ ] Asset images are added
- [ ] Related packages.json are upgraded
- [ ] Changelog is updated
