### PR TITLE
fix: putting in an input greater than 80 in the osmosis widget

### DIFF
--- a/packages/widgets/src/Osmosis/Osmosis.tsx
+++ b/packages/widgets/src/Osmosis/Osmosis.tsx
@@ -1,14 +1,13 @@
 "use client";
 import { Link } from "@evmosapps/i18n/client";
 import { useState } from "react";
-import { parseUnits } from "@ethersproject/units";
+import { parseUnits, formatUnits } from "@ethersproject/units";
 import { useOsmosisData } from "./useOsmosisData";
 import { cn, convertAndFormat, formatNumber } from "helpers";
 import { useOsmosisQoute } from "./useOsmosQuote";
 import { BigNumber } from "@ethersproject/bignumber";
 
 import { debounce } from "lodash";
-import { formatUnits } from "viem";
 import {
   ChevronDownIconOsmosis,
   DownArrowIconOsmosisIcon,
@@ -36,7 +35,9 @@ export default function Osmosis() {
 
   const number_min_received = parseFloat(
     formatUnits(
-      BigInt(latestQoute?.return_amount?.toString() ?? ""),
+      latestQoute?.return_amount?.toLocaleString("fullwide", {
+        useGrouping: false,
+      }) ?? "0",
       outputTokenData.decimals
     )
   );


### PR DESCRIPTION
# 🧙 Description

Fix: putting in an input greater than 80 in the osmosis widget
We were using `formatUnits` from viem and we had to import if from `@ethersproject/units`
Also it was crashing because the number was too big, and it was sent as ...e21

Ticket #fse-922

## ✅ Checklist

- [ ] Acceptance Criteria described in the ticket are met
- [ ] Texts and strings are in the related i18n file
- [ ] Utilities have unit tests
- [ ] User stories and functionalities have integration or e2e tests
- [ ] If adding a new token or network
  - [ ] Registry package is updated
  - [ ] Asset images are added
- [ ] Related packages.json are upgraded
- [ ] Changelog is updated
