### PR TITLE
fix: osmosis widget display values

### DIFF
--- a/packages/widgets/src/Osmosis/Osmosis.tsx
+++ b/packages/widgets/src/Osmosis/Osmosis.tsx
@@ -203,20 +203,14 @@ export default function Osmosis() {
               <input
                 value={swapAmountInputValue}
                 onKeyDown={(event) => {
-                  if (event.key === "-" || event.key === ".") {
+                  if (event.key === "-") {
                     event.preventDefault();
                   }
                 }}
                 onChange={(e) => {
                   setShowBalanceLink(false);
                   resetSwap();
-                  const _amount = parseFloat(e.target.value).toString();
-                  setSwapAmountInputValue(
-                    (typeof _amount === "number" && _amount === 0) ||
-                      _amount === "NaN"
-                      ? ""
-                      : _amount
-                  );
+                  setSwapAmountInputValue(e.target.value);
                 }}
                 placeholder="0"
                 type="number"
@@ -407,54 +401,55 @@ export default function Osmosis() {
               </div>
             )}
           </button>
-
-          <div className="absolute text-xs flex flex-col gap-4 pt-5 transition-opacity w-[358px] md:w-[94%]">
-            <div className="flex justify-between gap-1">
-              <span>Price Impact</span>
-              <span className="text-osmoverse-200">
-                {formatNumber(latestQuote?.price_impact, 4)}%
-              </span>
-            </div>
-            <div className="flex justify-between">
-              <span>Swap Fee (0.2%)</span>
-              {outputTokenData?.price && (
+          {enableDetails && (
+            <div className="absolute text-xs flex flex-col gap-4 pt-5 transition-opacity w-[358px] md:w-[94%]">
+              <div className="flex justify-between gap-1">
+                <span>Price Impact</span>
                 <span className="text-osmoverse-200">
-                  ≈ $
-                  {formatNumber(
-                    (number_min_received * outputTokenData.price * 0.2) / 100,
-                    4
-                  )}
+                  {formatNumber(latestQuote?.price_impact, 4)}%
                 </span>
-              )}
-            </div>
-            <hr className="text-white/20" />
-            <div className="flex justify-between gap-1">
-              <span className="max-w-[140px]">Expected Output</span>
-              <span className="whitespace-nowrap text-osmoverse-200">
-                ≈ {formatNumber(number_min_received, 5)}{" "}
-                {outputTokenData?.coinDenom}
-              </span>
-            </div>
-            <div className="flex justify-between gap-1">
-              <span className="max-w-[140px]">
-                Minimun received after slippage ({currentSlippage}%)
-              </span>
-              <div className="flex flex-col gap-0.5 text-right text-osmoverse-200">
-                <span className="whitespace-nowrap">
-                  {formatNumber(minReceivedAfterSlippage, 5)} OSMO
-                </span>
+              </div>
+              <div className="flex justify-between">
+                <span>Swap Fee (0.2%)</span>
                 {outputTokenData?.price && (
-                  <span>
+                  <span className="text-osmoverse-200">
                     ≈ $
                     {formatNumber(
-                      minReceivedAfterSlippage * outputTokenData.price,
-                      5
+                      (number_min_received * outputTokenData.price * 0.2) / 100,
+                      4
                     )}
                   </span>
                 )}
               </div>
+              <hr className="text-white/20" />
+              <div className="flex justify-between gap-1">
+                <span className="max-w-[140px]">Expected Output</span>
+                <span className="whitespace-nowrap text-osmoverse-200">
+                  ≈ {formatNumber(number_min_received, 5)}{" "}
+                  {outputTokenData?.coinDenom}
+                </span>
+              </div>
+              <div className="flex justify-between gap-1">
+                <span className="max-w-[140px]">
+                  Minimun received after slippage ({currentSlippage}%)
+                </span>
+                <div className="flex flex-col gap-0.5 text-right text-osmoverse-200">
+                  <span className="whitespace-nowrap">
+                    {formatNumber(minReceivedAfterSlippage, 5)} OSMO
+                  </span>
+                  {outputTokenData?.price && (
+                    <span>
+                      ≈ $
+                      {formatNumber(
+                        minReceivedAfterSlippage * outputTokenData.price,
+                        5
+                      )}
+                    </span>
+                  )}
+                </div>
+              </div>
             </div>
-          </div>
+          )}
         </div>
 
         <button
@@ -463,7 +458,8 @@ export default function Osmosis() {
             loading ||
             swapIsLoading ||
             number_min_received === 0 ||
-            enoughBalance === false
+            enoughBalance === false ||
+            swapAmount === 0
           }
           className={`${
             loading || swapIsLoading || number_min_received === 0


### PR DESCRIPTION
# 🧙 Description

Disable swap button if amount is 0. 
Allow entering 0.01 as a value

Ticket #

## ✅ Checklist

- [ ] Acceptance Criteria described in the ticket are met
- [ ] Texts and strings are in the related i18n file
- [ ] Utilities have unit tests
- [ ] User stories and functionalities have integration or e2e tests
- [ ] If adding a new token or network
  - [ ] Registry package is updated
  - [ ] Asset images are added
- [ ] Related packages.json are upgraded
- [ ] Changelog is updated
