### PR TITLE
fix: use 6 decimals instead of 3 on osmosis widget

### DIFF
--- a/packages/widgets/src/Osmosis/Osmosis.tsx
+++ b/packages/widgets/src/Osmosis/Osmosis.tsx
@@ -74,7 +74,7 @@ export default function Osmosis() {
     formatUnits(
       BigInt(inputTokenData?.balance ?? 0n),
       inputTokenData?.exponent ?? 0,
-      3
+      6
     )
   );
 


### PR DESCRIPTION
# 🧙 Description

Update: use 6 decimals instead of 3 on osmosis widget

Ticket #fse-942

## ✅ Checklist

- [ ] Acceptance Criteria described in the ticket are met
- [ ] Texts and strings are in the related i18n file
- [ ] Utilities have unit tests
- [ ] User stories and functionalities have integration or e2e tests
- [ ] If adding a new token or network
  - [ ] Registry package is updated
  - [ ] Asset images are added
- [ ] Related packages.json are upgraded
- [ ] Changelog is updated
