### PR TITLE
fix: blur widget until is connected

### DIFF
--- a/packages/instant-dapps/src/dapps/instant-dapp-container.tsx
+++ b/packages/instant-dapps/src/dapps/instant-dapp-container.tsx
@@ -17,8 +17,8 @@ export const InstantDappContainer = ({
   dappName,
   widget,
 }: ContainerProps) => {
-  const { isDisconnected } = useAccount();
-  if (isDisconnected) {
+  const { isConnected } = useAccount();
+  if (!isConnected) {
     return (
       <ConnectionRequired bgUrl={image} dappName={dappName}>
         <ConnectButton />


### PR DESCRIPTION
# 🧙 Description

Fix: blur widget until is connected. Use isConnected instead of isDisconnected

Ticket #fse-943

## ✅ Checklist

- [ ] Acceptance Criteria described in the ticket are met
- [ ] Texts and strings are in the related i18n file
- [ ] Utilities have unit tests
- [ ] User stories and functionalities have integration or e2e tests
- [ ] If adding a new token or network
  - [ ] Registry package is updated
  - [ ] Asset images are added
- [ ] Related packages.json are upgraded
- [ ] Changelog is updated
