### PR TITLE
fix: add x on connection modal and fix size images for EvmosRedIcon

### DIFF
--- a/packages/stateful-components/src/modals/ConnectModal/ConnectModalContent.tsx
+++ b/packages/stateful-components/src/modals/ConnectModal/ConnectModalContent.tsx
@@ -13,7 +13,7 @@ import {
 
 import { E, cn } from "helpers";
 
-import { Divider } from "@evmosapps/ui-helpers";
+import { Divider, Modal } from "@evmosapps/ui-helpers";
 import { useAccount, useConnect } from "wagmi";
 
 import {
@@ -122,6 +122,7 @@ export const ConnectModalContent = ({
   }, [isConnected, setIsOpen]);
   return (
     <div className="space-y-3">
+      <Modal.Header className=""></Modal.Header>
       <>
         <div className="md:mt-5">
           <ButtonWallet
@@ -132,7 +133,7 @@ export const ConnectModalContent = ({
               sendEvent(CLICK_EVMOS_COPILOT_START_FLOW);
             }}
           >
-            <EvmosRedIcon className="h-9 w-auto" />
+            <EvmosRedIcon className="h-9 w-auto shrink-0" />
             <div className="flex flex-col text-sm grow">
               <p className="">Evmos Copilot</p>
               <p className="font-normal">Recommended for first time users</p>

--- a/packages/ui-helpers/src/Modal.tsx
+++ b/packages/ui-helpers/src/Modal.tsx
@@ -124,7 +124,7 @@ const ModalHeader = ({
       >
         <CloseIcon
           className={cn(
-            "h-6 w-auto text-current focus:outline-none focus-visible:outline-none"
+            "h-6 w-auto absolute m-2 top-0 right-0 text-current focus:outline-none focus-visible:outline-none"
           )}
           aria-hidden="true"
         />

--- a/packages/ui-helpers/src/modal/Introduction.tsx
+++ b/packages/ui-helpers/src/modal/Introduction.tsx
@@ -18,7 +18,7 @@ export const IntroductionModal = ({
 }) => {
   return (
     <section className="flex flex-col space-y-3 text-gray1 h-full">
-      {icon ? icon : <EvmosRedIcon height={70} />}
+      {icon ? icon : <EvmosRedIcon className="shrink-0" />}
       <Title>{title}</Title>
       <Description>{description}</Description>
       <div className="flex flex-col space-y-2 text-xxs h-full justify-end">


### PR DESCRIPTION
# 🧙 Description

add x on connection modal
fix size images for EvmosRedIcon

Ticket #fse-946

## ✅ Checklist

- [ ] Acceptance Criteria described in the ticket are met
- [ ] Texts and strings are in the related i18n file
- [ ] Utilities have unit tests
- [ ] User stories and functionalities have integration or e2e tests
- [ ] If adding a new token or network
  - [ ] Registry package is updated
  - [ ] Asset images are added
- [ ] Related packages.json are upgraded
- [ ] Changelog is updated
