### PR TITLE
fix: close launchpad after clicking on view all dapps

### DIFF
--- a/apps/mission/src/components/header/LaunchPad.tsx
+++ b/apps/mission/src/components/header/LaunchPad.tsx
@@ -102,9 +102,17 @@ export function LaunchPad({}: { showPing?: boolean }) {
             event={CLICK_ON_VIEW_ALL_DAPPS}
             properties={{ Location: "App Launcher" }}
           >
-            <ButtonWithLink href="/dapps" className="w-full mt-2">
-              {t("launchPad.button")}
-            </ButtonWithLink>
+            <Menu.Item>
+              {({ close }) => (
+                <ButtonWithLink
+                  href="/dapps"
+                  className="w-full mt-2"
+                  onClick={close}
+                >
+                  {t("launchPad.button")}
+                </ButtonWithLink>
+              )}
+            </Menu.Item>
           </TrackerEvent>
         </Menu.Items>
       </Transition>


### PR DESCRIPTION
# 🧙 Description

Close launchpad after clicking on view all dapps. It was missing the close prop

Ticket #fse-947

## ✅ Checklist

- [ ] Acceptance Criteria described in the ticket are met
- [ ] Texts and strings are in the related i18n file
- [ ] Utilities have unit tests
- [ ] User stories and functionalities have integration or e2e tests
- [ ] If adding a new token or network
  - [ ] Registry package is updated
  - [ ] Asset images are added
- [ ] Related packages.json are upgraded
- [ ] Changelog is updated
