### PR TITLE
Release 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+## 2.0.1 - 2024-01-24
+
+- (fix) packages/helpers 1.0.12 | Adds absolute url to rpcs on wagmi config
 
 ## 2.0.0 - 2024-01-24
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evmos-apps",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "SEE LICENSE IN LICENSE",
   "author": "Tharsis Labs Ltd.(Evmos)",
   "private": true,

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helpers",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "main": "./src/index.tsx",
   "types": "./src/index.tsx",
   "type": "module",


### PR DESCRIPTION
## 2.0.1 - 2024-01-24

- (fix) packages/helpers 1.0.12 | Adds absolute url to rpcs on wagmi config