### PR TITLE
fix: pay modal images to lowercase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+- (fix) fse-960 | pages/portfolio 1.1.8 | Fix pay modal images
+
 ## 2.0.2 - 2024-01-29
 
 - (chore) packages/widgets 1.0.2 | Upgrade Foprge widget to 1.2.8

--- a/pages/portfolio/package.json
+++ b/pages/portfolio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evmosapps/portfolio-page",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "private": true,
   "type": "module",
   "main": "./src/index.tsx",

--- a/pages/portfolio/src/modals/common/AmountBox.tsx
+++ b/pages/portfolio/src/modals/common/AmountBox.tsx
@@ -22,7 +22,7 @@ export function AmountBox({
       <div className="flex items-center gap-2">
         <Image
           className="h-8 w-8 md:h-10 md:w-10 rounded-full"
-          src={`/tokens/${token.denom}.png`}
+          src={`/tokens/${token.denom.toLowerCase()}.png`}
           alt={token.denom}
           width={38}
           height={38}

--- a/pages/portfolio/src/modals/pay/Content.tsx
+++ b/pages/portfolio/src/modals/pay/Content.tsx
@@ -248,7 +248,7 @@ export const Content = ({
                             src={`/tokens/${
                               b?.type === "ERC20"
                                 ? "evmos"
-                                : selectedBalance?.denom
+                                : selectedBalance?.denom.toLowerCase()
                             }.png`}
                             key={b?.address}
                             value={b?.type ?? ""}


### PR DESCRIPTION
# 🧙 Description

Images in pay modal were not showing correctly.
Add lowercase to fix the issue

Ticket #fse-960

## ✅ Checklist

- [ ] Acceptance Criteria described in the ticket are met
- [ ] Texts and strings are in the related i18n file
- [ ] Utilities have unit tests
- [ ] User stories and functionalities have integration or e2e tests
- [ ] If adding a new token or network
  - [ ] Registry package is updated
  - [ ] Asset images are added
- [ ] Related packages.json are upgraded
- [ ] Changelog is updated
