### PR TITLE
chore: use msw for mocking responses

### DIFF
--- a/apps/mission/src/components/header/WalletButton.spec.tsx
+++ b/apps/mission/src/components/header/WalletButton.spec.tsx
@@ -1,7 +1,7 @@
 // Copyright Tharsis Labs Ltd.(Evmos)
 // SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
 
-import { test, describe, expect, vi } from "vitest";
+import { test, describe, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { RootProviders } from "stateful-components/src/root-providers";
@@ -13,37 +13,6 @@ import {
 
 import { MIXPANEL_TOKEN_FOR_TEST } from "../../../vitest.setup";
 import { WalletButton } from "./WalletButton";
-
-vi.mock("react", async (importOriginal: () => Promise<{}>) => {
-  return {
-    ...(await importOriginal()),
-
-    cache: (fn: unknown) => fn,
-    "server-only": {},
-  };
-});
-vi.mock("@tanstack/react-query-next-experimental", () => ({
-  ReactQueryStreamedHydration: (props: React.PropsWithChildren<{}>) =>
-    props.children,
-}));
-
-vi.mock(
-  "@evmosapps/evmos-wallet",
-  async (importOriginal: () => Promise<{}>) => {
-    return {
-      ...(await importOriginal()),
-      useWallet: () => {
-        return {
-          connector: vi.fn(),
-          address: "",
-          isHydrating: false,
-          isConnecting: false,
-          isReconnecting: false,
-        };
-      },
-    };
-  },
-);
 
 describe("Testing Branding", () => {
   const wrapper = ({ children }: { children: JSX.Element }) => {

--- a/apps/mission/vitest.setup.ts
+++ b/apps/mission/vitest.setup.ts
@@ -11,6 +11,38 @@ import { enableMixpanel, localMixpanel as mixpanel } from "tracker";
 setConfig(config);
 
 export const MIXPANEL_TOKEN_FOR_TEST = "testToken";
+
+vi.mock("react", async (importOriginal: () => Promise<{}>) => {
+  return {
+    ...(await importOriginal()),
+
+    cache: (fn: unknown) => fn,
+    "server-only": {},
+  };
+});
+vi.mock("@tanstack/react-query-next-experimental", () => ({
+  ReactQueryStreamedHydration: (props: React.PropsWithChildren<{}>) =>
+    props.children,
+}));
+
+vi.mock(
+  "@evmosapps/evmos-wallet",
+  async (importOriginal: () => Promise<{}>) => {
+    return {
+      ...(await importOriginal()),
+      useWallet: () => {
+        return {
+          connector: vi.fn(),
+          address: "",
+          isHydrating: false,
+          isConnecting: false,
+          isReconnecting: false,
+        };
+      },
+    };
+  },
+);
+
 const initializeMixpanelAndEnable = () => {
   mixpanel.init(MIXPANEL_TOKEN_FOR_TEST, { ip: false });
   enableMixpanel();

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "eslint-plugin-vitest": "^0.3.20",
     "husky": "^8.0.0",
     "knip": "4.0.0-canary.8",
+    "msw": "^2.1.5",
     "prettier": "^3.0.1",
     "react-dom": "^18.2.0",
     "viem": "^2.0.6",

--- a/packages/stateful-components/src/modals/ConnectModal/connect-modal-content.spec.tsx
+++ b/packages/stateful-components/src/modals/ConnectModal/connect-modal-content.spec.tsx
@@ -1,39 +1,25 @@
 // Copyright Tharsis Labs Ltd.(Evmos)
 // SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
 
-import { test, describe, expect, vi } from "vitest";
+import { test, describe, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import {
   CLICK_CONNECTED_WITH,
   CLICK_EVMOS_COPILOT_START_FLOW,
-  UNSUCCESSFUL_WALLET_CONNECTION,
   disableMixpanel,
   localMixpanel as mixpanel,
 } from "tracker";
 import { RootProviders } from "../../root-providers";
-import { PropsWithChildren } from "react";
 import { ConnectModalContent } from "./ConnectModalContent";
 import { MIXPANEL_TOKEN_FOR_TEST } from "../../../vitest.setup";
 
-vi.mock("@tanstack/react-query-next-experimental", () => ({
-  ReactQueryStreamedHydration: (props: PropsWithChildren<{}>) => props.children,
-}));
-
-vi.mock("react", async (importOriginal: () => Promise<{}>) => {
-  return {
-    ...(await importOriginal()),
-
-    cache: (fn: unknown) => fn,
-    "server-only": {},
-  };
-});
 describe("Testing Connect Modal Content", () => {
   const wrapper = ({ children }: { children: JSX.Element }) => {
     return <RootProviders>{children}</RootProviders>;
   };
-  test("should call mixpanel event for connect specific wallet + failed connection", async () => {
+  test("should call mixpanel event for connect specific wallet", async () => {
     render(<ConnectModalContent setIsOpen={() => true} />, { wrapper });
     const button = screen.getByTestId(/connect-with-metaMask/);
     expect(button).toBeDefined();
@@ -41,17 +27,9 @@ describe("Testing Connect Modal Content", () => {
     expect(mixpanel.init).toHaveBeenCalledOnce();
     expect(mixpanel.track).toHaveBeenCalledWith(CLICK_CONNECTED_WITH, {
       token: MIXPANEL_TOKEN_FOR_TEST,
-      "Wallet Provider": "metamask",
+      "Wallet Provider": "metaMask",
     });
-    expect(mixpanel.track).toHaveBeenCalledWith(
-      UNSUCCESSFUL_WALLET_CONNECTION,
-      {
-        token: MIXPANEL_TOKEN_FOR_TEST,
-        "Error Message": "Failed to connect with MetaMask",
-        "Wallet Provider": "metamask",
-      },
-    );
-    expect(mixpanel.track).toHaveBeenCalledTimes(2);
+    expect(mixpanel.track).toHaveBeenCalledTimes(1);
   });
 
   test("should not call mixpanel event for connect specific wallet + failed connection", async () => {

--- a/packages/stateful-components/src/modals/ProfileModal/profile-modal.spec.tsx
+++ b/packages/stateful-components/src/modals/ProfileModal/profile-modal.spec.tsx
@@ -12,52 +12,7 @@ import {
 
 import { ProfileModal } from "./ProfileModal";
 import { RootProviders } from "../../root-providers";
-import { PropsWithChildren } from "react";
-import { MIXPANEL_TOKEN_FOR_TEST } from "../../../vitest.setup";
-
-const ResizeObserver = vi.fn(() => ({
-  observe: vi.fn(),
-  unobserve: vi.fn(),
-  disconnect: vi.fn(),
-}));
-vi.mock("@tanstack/react-query-next-experimental", () => ({
-  ReactQueryStreamedHydration: (props: PropsWithChildren<{}>) => props.children,
-}));
-
-vi.mock("wagmi", async (importOriginal: () => Promise<{}>) => {
-  return {
-    ...(await importOriginal()),
-    useAccount: () => {
-      return {
-        isDisconnected: false,
-        address: "0x1234567890123456789012345678901234567890",
-        connector: {
-          id: "metaMask",
-        },
-      };
-    },
-  };
-});
-
-vi.mock("helpers", async (importOriginal: () => Promise<{}>) => {
-  return {
-    ...(await importOriginal()),
-    useModal: () => ({
-      isOpen: true,
-      setIsOpen: vi.fn(),
-    }),
-  };
-});
-
-vi.mock(
-  "@evmosapps/evmos-wallet",
-  async (importOriginal: () => Promise<{}>) => {
-    return {
-      ...(await importOriginal()),
-      getActiveProviderKey: () => "Keplr",
-    };
-  },
-);
+import { MIXPANEL_TOKEN_FOR_TEST, ResizeObserver } from "../../../vitest.setup";
 
 describe("Testing Profile Modal", () => {
   const wrapper = ({ children }: { children: JSX.Element }) => {

--- a/packages/stateful-components/vitest.setup.ts
+++ b/packages/stateful-components/vitest.setup.ts
@@ -6,6 +6,68 @@ import { afterEach, beforeEach, vi } from "vitest";
 import { enableMixpanel, localMixpanel as mixpanel } from "tracker";
 
 export const MIXPANEL_TOKEN_FOR_TEST = "testToken";
+
+vi.mock("@tanstack/react-query-next-experimental", () => ({
+  ReactQueryStreamedHydration: (props: React.PropsWithChildren<{}>) =>
+    props.children,
+}));
+
+vi.mock("react", async (importOriginal: () => Promise<{}>) => {
+  return {
+    ...(await importOriginal()),
+
+    cache: (fn: unknown) => fn,
+    "server-only": {},
+  };
+});
+
+export const ResizeObserver = vi.fn(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+}));
+
+vi.mock("wagmi", async (importOriginal: () => Promise<{}>) => {
+  return {
+    ...(await importOriginal()),
+    useAccount: () => {
+      return {
+        isDisconnected: false,
+        address: "0x1234567890123456789012345678901234567890",
+        connector: {
+          id: "metaMask",
+        },
+      };
+    },
+    useConnect: () => {
+      return {
+        connect: vi.fn(),
+        connectors: [{ name: "metaMask", id: "metaMask" }],
+      };
+    },
+  };
+});
+
+vi.mock("helpers", async (importOriginal: () => Promise<{}>) => {
+  return {
+    ...(await importOriginal()),
+    useModal: () => ({
+      isOpen: true,
+      setIsOpen: vi.fn(),
+    }),
+  };
+});
+
+vi.mock(
+  "@evmosapps/evmos-wallet",
+  async (importOriginal: () => Promise<{}>) => {
+    return {
+      ...(await importOriginal()),
+      getActiveProviderKey: () => "Keplr",
+    };
+  },
+);
+
 const initializeMixpanelAndEnable = () => {
   mixpanel.init(MIXPANEL_TOKEN_FOR_TEST, { ip: false });
   enableMixpanel();

--- a/pages/dappstore/mocks/handlers.ts
+++ b/pages/dappstore/mocks/handlers.ts
@@ -1,0 +1,125 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
+
+import { http, HttpResponse } from "msw";
+// 44f82b8afefe4815bc072f34d37c8619
+export const handlers = [
+  http.post(
+    // eslint-disable-next-line no-secrets/no-secrets
+    "https://api.notion.com/v1/databases/00c57b8ac577430a9a6b855192da6493/query",
+    () => {
+      return HttpResponse.json(
+        {
+          object: "list",
+          results: [
+            {
+              object: "page",
+              id: "44f82b8a-fefe-4815-bc07-2f34d37c8619",
+              created_time: "2024-01-22T14:15:00.000Z",
+              last_edited_time: "2024-01-22T14:26:00.000Z",
+              created_by: {},
+              last_edited_by: {},
+              cover: null,
+              icon: null,
+              parent: {},
+              archived: false,
+              properties: {},
+              // eslint-disable-next-line no-secrets/no-secrets
+              url: "https://www.notion.so/Gaming-44f82b8afefe4815bc072f34d37c8619",
+              public_url:
+                // eslint-disable-next-line no-secrets/no-secrets
+                "https://altiplanic.notion.site/Gaming-44f82b8afefe4815bc072f34d37c8619",
+            },
+          ],
+          next_cursor: null,
+          has_more: false,
+          type: "page_or_database",
+          page_or_database: {},
+          request_id: "41b011f1-b060-4bdd-8b5b-ed78310b827f",
+        },
+
+        { status: 200 },
+      );
+    },
+  ),
+  http.post(
+    "https://api.notion.com/v1/databases/a188bd13dd114a88a7763fd2a8cc601e/query",
+    () => {
+      return HttpResponse.json(
+        {
+          object: "list",
+          results: [
+            {
+              object: "page",
+              id: "600c7bc5-4960-4ecf-8700-be82aef554cd",
+              created_time: "2023-11-01T10:27:00.000Z",
+              last_edited_time: "2024-01-20T01:20:00.000Z",
+              created_by: [Object],
+              last_edited_by: [Object],
+              cover: null,
+              icon: [Object],
+              parent: [Object],
+              archived: false,
+              properties: [Object],
+              // eslint-disable-next-line no-secrets/no-secrets
+              url: "https://www.notion.so/Evmos-Governance-600c7bc549604ecf8700be82aef554cd",
+              public_url: null,
+            },
+            {
+              object: "page",
+              id: "64517aa9-1545-4afc-a4ea-d84e0cca4da7",
+              created_time: "2023-11-01T10:26:00.000Z",
+              last_edited_time: "2024-01-20T01:20:00.000Z",
+              created_by: [Object],
+              last_edited_by: [Object],
+              cover: null,
+              icon: [Object],
+              parent: [Object],
+              archived: false,
+              properties: [Object],
+              url: "https://www.notion.so/Evmos-Staking-64517aa915454afca4ead84e0cca4da7",
+              public_url: null,
+            },
+            {
+              object: "page",
+              id: "bdc9e06f-d3dc-4699-96f6-aba4767a48a3",
+              created_time: "2023-11-01T09:23:00.000Z",
+              last_edited_time: "2024-01-20T01:18:00.000Z",
+              created_by: [Object],
+              last_edited_by: [Object],
+              cover: null,
+              icon: [Object],
+              parent: [Object],
+              archived: false,
+              properties: [Object],
+              url: "https://www.notion.so/Revert-bdc9e06fd3dc469996f6aba4767a48a3",
+              public_url: null,
+            },
+            {
+              object: "page",
+              id: "d218a02f-72d8-421b-a810-6c15b2bf1bca",
+              created_time: "2023-11-01T09:21:00.000Z",
+              last_edited_time: "2024-01-20T01:18:00.000Z",
+              created_by: [Object],
+              last_edited_by: [Object],
+              cover: null,
+              icon: [Object],
+              parent: [Object],
+              archived: false,
+              properties: [Object],
+              url: "https://www.notion.so/Steer-d218a02f72d8421ba8106c15b2bf1bca",
+              public_url: null,
+            },
+          ],
+          next_cursor: null,
+          has_more: false,
+          type: "page_or_database",
+          page_or_database: {},
+          request_id: "41b011f1-b060-4bdd-8b5b-ed78310b827f",
+        },
+
+        { status: 200 },
+      );
+    },
+  ),
+];

--- a/pages/dappstore/mocks/server.ts
+++ b/pages/dappstore/mocks/server.ts
@@ -1,0 +1,7 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
+
+import { setupServer } from "msw/node";
+import { handlers } from "./handlers";
+
+export const server = setupServer(...handlers);

--- a/pages/dappstore/src/pages/dapp-explorer/partials/description-section.spec.tsx
+++ b/pages/dappstore/src/pages/dapp-explorer/partials/description-section.spec.tsx
@@ -5,9 +5,7 @@ import { test, describe, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 
 import { DescriptiondApp } from "./description-section";
-
-// const TOKEN = "testToken";
-
+type TYPE_IMAGE = "file";
 const DAPP = {
   name: "Stride ",
   slug: "stride",
@@ -42,18 +40,27 @@ const DAPP = {
       // eslint-disable-next-line no-secrets/no-secrets
       "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAADCAYAAACasY9UAAAACXBIWXMAABYlAAAWJQFJUiTwAAAAYElEQVR4nI2OsQ5AMAAF/f8/2Y1iMFhEGgNCldIq7UkkFgyGWy4vlxdhPU+COXDKIEXL2k/geG1uorcM+HXHmx0rF3Qz4mZ7Rdl+BA7t0J0ijROqrGBuJHVeMoiW8PHgBI/Kut5al1DBAAAAAElFTkSuQmCC",
     src: "/prefetched-images/stride-cover-d9c0931f.png",
+    _originalSrc: "",
+    type: "file" as TYPE_IMAGE,
+    expiryTime: "",
   },
   thumbnail: {
     blurDataURL:
       // eslint-disable-next-line no-secrets/no-secrets
       "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAKCAYAAAC9vt6cAAAACXBIWXMAABYlAAAWJQFJUiTwAAABv0lEQVR4nF2Sy2pUQRCGz86diOAiC92IzyH4EqJbX8CtoIIkIOQFXJilELJQEF0FdKOBgAslQmYSM84wZ8792ufW5zb9SfeAGBuqq6Grvvq7qi06RS8kXd7QRIImKWmzGpmUrJuBoez4cXhk7umBdn3JLL2t5WgCqiBHphVKjtRBzih7woXD4esD6rgwAKUTu/8AtMpAhkIagHAiYi+kmAV0juDk6zeimWMAY9Wzbvq/EOuSpE6BHOn7gfjVEe7VF/hbL5k+e0sepTShQDgxmR1Cr4xS61+AakYYofcKVje3ye7vIx5/xLuxTTxdkTkR/tkS4Sab5wwKS1M2yQOqHWFQSCfHvrVD8egd4uEB9tYOYhEyVC11JExlbcKNsRhgqDqEl+Bf2OR2xKgUzt4XZtefc3HtKae7H9CrS2vTTN3IUQ6sTudYhZ/SxAUyq0idEBFk1KGgFCXOZI53viT2IyNbj9Q/X1L6mZlYX7dYv79PKIMMDdLenS5wJ3MqL9tITgqTHM5W9IU0Zx0TXNh0QmLpjxPNXc6OT3hw5y73rtxm78kuhZuQryLavCZeeHx6856fn48Jftmky8BMQxf9AyelS9exBwMiAAAAAElFTkSuQmCC",
     src: "/prefetched-images/stride-thumbnail-41d45f39.png",
+    _originalSrc: "",
+    type: "file" as TYPE_IMAGE,
+    expiryTime: "",
   },
   icon: {
     blurDataURL:
       // eslint-disable-next-line no-secrets/no-secrets
       "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAACXBIWXMAAAsTAAALEwEAmpwYAAABiElEQVR4nKWTO0sDQRSF7yaLja3WVta2wcpeC3+BjYV2amLiblYRQRADFiKIoo2KhYUgoqBo4YNUdkEiqBCV3TFvE/J+HpmJYhJMjGRgGBjmfjPnnDvEyIl2JrV00KS1BzDIAUbqPwDmWTD5a5qcCPaugHXOg0ktAAxJhU5T0M2TeKMxREf2UfAGoHdYoZMVTNIaACS+qmCdc4iNHyGxdIW44wzZy2eUPjJILN8gMrQLg2ZqIPTzbA0G2ZBcdaMUTSN7/oic+wVFXxTlVB55j18ADbLXmErVTutkQ/rAg4I3iPeuBbzSKOLKKYp6HIbsqBQ3lqDBIAX+7kVkL55QzuQRsqwjPnGCIouByUpFotTMREkDM3ETp5E5vEfu1id08xGybFTirOsJqpbAn5javkM5mUM5kUPCdS2KMscPAhIZ3BEyRcy/p6Ag1LeGyPAewv2bYLIqXDdkFeGBLQR6XE1SoO+us4u8uQwB5Yclp7hZFP/ZiVyjmXtR1/98ry6B1j9T27+xCeAT7dKJ1t9yWHEAAAAASUVORK5CYII=",
     src: "/prefetched-images/stride-icon-68a73297.png",
+    _originalSrc: "",
+    type: "file" as TYPE_IMAGE,
+    expiryTime: "",
   },
 };
 
@@ -91,6 +98,9 @@ const RELATED_APPS = [
         // eslint-disable-next-line no-secrets/no-secrets
         "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAKCAYAAAC9vt6cAAAACXBIWXMAABYlAAAWJQFJUiTwAAACJklEQVR4nB3PS0tUcRiA8fd/7mfONBdnnHEcpxQzYdIcdbwQJ5VEDS9oCokSaHZBXJq0k4kiXERmRW2iKCSQoIUgJURpYtoiiEiQglq06ls8oR/ggd8jobKblPevUjK0RuLSNyL+G9JXv5Ka/Ue0d4NY4BrRwBilZ+4SKZ7BSdzADE1gaj6Glkfi2cfE2ldJtjwjM/WZaNsaZfN/KRp+RXBqH2/yN9G6h8RqnuA2rGAeW0APjaMrH13qEa/qEZH0InH3OtHYAvEre4SGNtDC96nue0Dd8h+sZIEjJRN4rYsosxe79QWhuW2CsVkkWHGbcOoW3sVN3NPbRFPTiDbKeOEee/sV7Oxk6BkaR0kXbmoUpedQWjVuxRxWzTpiN68QrF0m0PcazxvDiRcozU6z/raY3d0EW5tFbGyfJNH2HNGbUVKJkhMoowHd6UCs+pe4lXewvQEsoxM7fpmMP8/m+xjff6R4t57iw8ckRa1LaJVLmOE+lBxH5CgiGcQY+YJxdAZl5jDDg+h6DpF2hifP8fNXiq1PCbq6s0ikH7N6GjN6Hic+gu7kEUkjxsBTbC2PkioMrxvdPYthNKESkwTKR/DsUnTrFHrQR5waRMrQ7UasxBBGqBMxpQVRTSjJoZk+gdAFLGnEKhnGyM5jSB5llGMHOg7/RR3wM4cLhtOCOFoPlvLRpAmRWrxMAcP2MaUW22zD9Qax7XYstxPdOGAfxGlEpRFJ8h+E5QUX6foyGAAAAABJRU5ErkJggg==",
       src: "/prefetched-images/disperze-thumbnail-9f047454.png",
+      _originalSrc: "",
+      type: "file" as TYPE_IMAGE,
+      expiryTime: "",
     },
     icon: null,
   },
@@ -124,6 +134,9 @@ const RELATED_APPS = [
         // eslint-disable-next-line no-secrets/no-secrets
         "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAKCAYAAAC9vt6cAAAACXBIWXMAABYlAAAWJQFJUiTwAAACJElEQVR4nCWRW0sTAACFzxipQ9NNN5s0S0NUFDEhmZoPamipaIlpZmpe09LMSyYoRSJKBEqiRlQY5GsPEV0ESSqCwHqwJ6NelGWzjEaGXUj6Yu4HHM73nSPPwnP4swHuD2w+meDHWC2rF7Jxte7jU3saS40JzB8yMZspxhPExSjREyk6HaItQmgr7HHzd+Y6GzfO8HWgmJX2dFxnnbjbUpjP8+OBU0yniNtJ4mqs6HKI5ghRYRX653HD2xnWxxvZmOrm51QXrrY0PlZHMZcTwJ29YjJBDMeIkTjRu0vUh4samygP8xK8f8Xvuz14Rmv4dqWc5fNZfD6XSn+cAbPJn2A/I6V2I9fixeU9oiVCnAwXZWHiiEVoc/Ym62N1rE82864unvl8E3P5ZuLsFlpON5Cbm4UzKZY+r3ekgapwUWUTR8NEYYjQr+levgyW4plo4UVeEE+z/XmUE0RxdhpDg/0kJycSErCNSpuotvm8ve1FZnEwWMgzUsXqQAlrw2XMZBp5lhvIywP+dMQYCA00YQ40sX+7qLf7nEtDRbFZ5IeIIi+BqyOT7xPNLHVm8ibfxGKFg3up4mG6gb5ocdwqmiIMVFp92MUWUWgWJRbR6r1xudWJZ7SWxRNRvM41cD/DuHXVrSQxFCOa7KJhhzhm9Y3mbS4IEdVW0e0QWrtUwEq7k4XDFh5niMlEw9ba/dGid7c4ZfdRlIT6RvO6e5/o3ClqrOI/G4g/aevx1iEAAAAASUVORK5CYII=",
       src: "/prefetched-images/evmos-staking-thumbnail-0f1a33d2.png",
+      _originalSrc: "",
+      type: "file" as TYPE_IMAGE,
+      expiryTime: "",
     },
     icon: null,
   },
@@ -160,6 +173,9 @@ const RELATED_APPS = [
         // eslint-disable-next-line no-secrets/no-secrets
         "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAKCAYAAAC9vt6cAAAACXBIWXMAABYlAAAWJQFJUiTwAAACBElEQVR4nE3S3UtTARjH8UPZ3Ktn7zvzuJ1t5+x9c3Oz6WbWbKPZsoVBIFgJgRQUWRRddBG90kXvoCAYBIWRsEIIioKgi0BC6CIIgi6CLurP+MbcLP+D5/N8f0JNEpmUbUz7HcwGXZwLe7gc83IjKXM/42Mxr/C0EKRZVHkzGuFjOcZ6JcG3Woqf9X6EsstMXRI50mdjRnFwSnVxIeLhSqKXW2mZh1kfjwcDLA8FWR3ReLc7wqexGF+qCb6PpxBKDjNVdw+NXitTPjsnAk7OaG7ORzzcTLWveJT182RnkJVhldcjYT7sibK2N87XfUmEvM3EqNNCzdOmHFMczAScLA0G+NPI8vtghmZJY2FA4VkhRLOo8XYLRUiJBgp2E2MuCwe8IodlK6c1Ny9LKhejEq9KGj/2p5nP+VnKKzwfCrFa0njfoQhhs56MaGSD4ulhwmvluOJgvZrgxbDKUcXB50qcexkf8wNbKLvaFEExdhO3GNikjEsida/I9aTMr4kMa5U4dzM+riZlHmRbVQL/qrQogqTfQcjUTbpDKXcoDdnKlN/OSdXNXLhd5Xa6b+Ohrf8stygjGoJd14Vs0BGx6Mla/1MObalyVnNzKSpxLSlzp9/HQk5pU4oqgnH7Npy6LhSjjphFT85mZNRppubpYVK2Mu23MxtyMhd2bwxsM+1irj2wv+4kFT+5K/jEAAAAAElFTkSuQmCC",
       src: "/prefetched-images/stayking-thumbnail-7e9ee090.png",
+      _originalSrc: "",
+      type: "file" as TYPE_IMAGE,
+      expiryTime: "",
     },
     icon: null,
   },

--- a/pages/dappstore/src/pages/dapp-explorer/partials/explorer-breadcrumbs.spec.tsx
+++ b/pages/dappstore/src/pages/dapp-explorer/partials/explorer-breadcrumbs.spec.tsx
@@ -1,7 +1,7 @@
 // Copyright Tharsis Labs Ltd.(Evmos)
 // SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
 
-import { test, describe, expect, vi } from "vitest";
+import { test, describe, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
@@ -10,56 +10,24 @@ import {
   localMixpanel as mixpanel,
 } from "tracker";
 import { ExplorerBreadcrumbs } from "./explorer-breadcrumbs";
-import { PropsWithChildren } from "react";
-
-vi.mock("@tanstack/react-query-next-experimental", () => ({
-  ReactQueryStreamedHydration: (props: PropsWithChildren<{}>) => props.children,
-}));
-
-vi.mock("react", async (importOriginal: () => Promise<{}>) => {
-  return {
-    ...(await importOriginal()),
-    cache: (fn: unknown) => fn,
-  };
-});
-
-const MOCK_CATEGORIES = [
-  "DeFi",
-  "NFTs",
-  "Games",
-  "DAOs",
-  "Infrastructure",
-  "Social",
-].map((name) => ({ name, slug: name.toLowerCase() }));
-
-const TOKEN = "testToken";
-const MOCK_DAPPS = ["Forge", "Stride", "Wormhole"].map((name) => ({
-  name,
-  slug: name.toLowerCase(),
-}));
-vi.mock("../../../lib/fetch-explorer-data", () => ({
-  fetchExplorerData: () => {
-    return { categories: MOCK_CATEGORIES, dApps: MOCK_DAPPS };
-  },
-}));
+import { MIXPANEL_TOKEN_FOR_TEST } from "../../../../vitest.setup";
 
 describe("Testing Explorer Breadcrumbs", () => {
   test("should call mixpanel event for breadcrumbs clicks", async () => {
     render(
       await ExplorerBreadcrumbs({
         params: {
-          category: MOCK_CATEGORIES[2]!.slug,
-          dapp: MOCK_DAPPS[1]!.slug,
+          category: "dapps",
         },
       }),
     );
-    const button = screen.getByText(MOCK_CATEGORIES[2]!.name);
+    const button = screen.getByText(/dApp Store/i);
     expect(button).toBeDefined();
     await userEvent.click(button);
     expect(mixpanel.init).toHaveBeenCalledOnce();
     expect(mixpanel.track).toHaveBeenCalledWith(CLICK_ON_BREADCRUMB, {
-      Breadcrumb: MOCK_CATEGORIES[2]!.name,
-      token: TOKEN,
+      Breadcrumb: "dApp Store",
+      token: MIXPANEL_TOKEN_FOR_TEST,
     });
   });
 
@@ -68,13 +36,12 @@ describe("Testing Explorer Breadcrumbs", () => {
     render(
       await ExplorerBreadcrumbs({
         params: {
-          category: MOCK_CATEGORIES[2]!.slug,
-          dapp: MOCK_DAPPS[1]!.slug,
+          category: "dapps",
         },
       }),
     );
 
-    const button = screen.getByText(MOCK_CATEGORIES[2]!.name);
+    const button = screen.getByText(/All/i);
     expect(button).toBeDefined();
     await userEvent.click(button);
     expect(mixpanel.init).toHaveBeenCalledOnce();

--- a/pages/dappstore/src/pages/landing/partials/account-balance.spec.tsx
+++ b/pages/dappstore/src/pages/landing/partials/account-balance.spec.tsx
@@ -1,7 +1,7 @@
 // Copyright Tharsis Labs Ltd.(Evmos)
 // SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
 
-import { test, describe, expect, vi } from "vitest";
+import { test, describe, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
@@ -10,33 +10,9 @@ import {
   localMixpanel as mixpanel,
 } from "tracker";
 import { RootProviders } from "stateful-components/src/root-providers";
-import { PropsWithChildren } from "react";
 import { AccountBalance } from "./account-balance";
 import { MIXPANEL_TOKEN_FOR_TEST } from "../../../../vitest.setup";
 
-vi.mock("@tanstack/react-query-next-experimental", () => ({
-  ReactQueryStreamedHydration: (props: PropsWithChildren<{}>) => props.children,
-}));
-
-vi.mock("react", async (importOriginal: () => Promise<{}>) => {
-  return {
-    ...(await importOriginal()),
-
-    cache: (fn: unknown) => fn,
-    "server-only": {},
-  };
-});
-
-vi.mock("wagmi", async (importOriginal: () => Promise<{}>) => {
-  return {
-    ...(await importOriginal()),
-    useAccount: () => {
-      return {
-        isConnected: true,
-      };
-    },
-  };
-});
 describe("Testing Setup success step", () => {
   const wrapper = ({ children }: { children: JSX.Element }) => {
     return <RootProviders>{children}</RootProviders>;

--- a/pages/dappstore/src/pages/landing/partials/copilot-card/copilot-card.spec.tsx
+++ b/pages/dappstore/src/pages/landing/partials/copilot-card/copilot-card.spec.tsx
@@ -1,27 +1,13 @@
 // Copyright Tharsis Labs Ltd.(Evmos)
 // SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
 
-import { test, describe, expect, vi } from "vitest";
+import { test, describe, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { CopilotCard } from "./copilot-card";
-import { PropsWithChildren } from "react";
+
 import { RootProviders } from "stateful-components/src/root-providers";
 
-vi.mock("@tanstack/react-query-next-experimental", () => ({
-  ReactQueryStreamedHydration: (props: PropsWithChildren<{}>) => props.children,
-}));
-vi.mock("react", async (importOriginal: () => Promise<{}>) => {
-  return {
-    ...(await importOriginal()),
-
-    cache: (fn: unknown) => fn,
-    "server-only": {},
-  };
-});
-
-// TypeError: getActiveProviderKey is not a function
-
-describe.skip("Testing Copilot Card", () => {
+describe("Testing Copilot Card", () => {
   const wrapper = ({ children }: { children: JSX.Element }) => {
     return <RootProviders>{children}</RootProviders>;
   };

--- a/pages/dappstore/src/pages/landing/partials/ecosystem-section.spec.tsx
+++ b/pages/dappstore/src/pages/landing/partials/ecosystem-section.spec.tsx
@@ -1,7 +1,7 @@
 // Copyright Tharsis Labs Ltd.(Evmos)
 // SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
 
-import { test, describe, expect, vi } from "vitest";
+import { test, describe, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
@@ -11,38 +11,7 @@ import {
 } from "tracker";
 
 import { EcosystemSection } from "./ecosystem-section";
-import { PropsWithChildren } from "react";
-vi.mock("@tanstack/react-query-next-experimental", () => ({
-  ReactQueryStreamedHydration: (props: PropsWithChildren<{}>) => props.children,
-}));
-
-const MOCK_CATEGORIES = [
-  "DeFi",
-  "NFTs",
-  "Games",
-  "DAOs",
-  "Infrastructure",
-  "Social",
-].map((name) => ({ name, slug: name.toLowerCase() }));
-
-const TOKEN = "testToken";
-const MOCK_DAPPS = ["Forge", "Stride", "Wormhole"].map((name) => ({
-  name,
-  slug: name.toLowerCase(),
-}));
-vi.mock("../../../lib/fetch-explorer-data", () => ({
-  fetchExplorerData: () => {
-    return { categories: MOCK_CATEGORIES, dApps: MOCK_DAPPS };
-  },
-}));
-
-vi.mock("react", async (importOriginal: () => Promise<{}>) => {
-  return {
-    ...(await importOriginal()),
-
-    cache: (fn: unknown) => fn,
-  };
-});
+import { MIXPANEL_TOKEN_FOR_TEST } from "../../../../vitest.setup";
 
 describe("Testing Ecosystem section", () => {
   test("should call mixpanel event when clicking on see more button", async () => {
@@ -52,12 +21,12 @@ describe("Testing Ecosystem section", () => {
     await userEvent.click(button);
     expect(mixpanel.init).toHaveBeenCalledOnce();
     expect(mixpanel.track).toHaveBeenCalledWith(CLICK_SEE_MORE_BUTTON, {
-      token: TOKEN,
+      token: MIXPANEL_TOKEN_FOR_TEST,
     });
     expect(mixpanel.track).toHaveBeenCalledTimes(1);
   });
   //   Error: A component suspended while responding to synchronous input. This will cause the UI to be replaced with a loading indicator. To fix, updates that suspend should be wrapped with startTransition.
-  test.skip("should not call mixpanel event when clicking on see more button", async () => {
+  test("should not call mixpanel event when clicking on see more button", async () => {
     disableMixpanel();
     render(await EcosystemSection());
     const button = await screen.findByRole("link", { name: "See More" });

--- a/pages/dappstore/vitest.setup.ts
+++ b/pages/dappstore/vitest.setup.ts
@@ -2,19 +2,49 @@
 // SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
 
 import { cleanup } from "@testing-library/react";
-import { afterEach, beforeEach, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, vi } from "vitest";
 import { enableMixpanel, localMixpanel as mixpanel } from "tracker";
+import { server } from "./mocks/server";
+import { PropsWithChildren } from "react";
 
 export const MIXPANEL_TOKEN_FOR_TEST = "testToken";
+
+vi.mock("@tanstack/react-query-next-experimental", () => ({
+  ReactQueryStreamedHydration: (props: PropsWithChildren<{}>) => props.children,
+}));
+
+vi.mock("react", async (importOriginal: () => Promise<{}>) => {
+  return {
+    ...(await importOriginal()),
+    cache: (fn: unknown) => fn,
+  };
+});
+
+vi.mock("wagmi", async (importOriginal: () => Promise<{}>) => {
+  return {
+    ...(await importOriginal()),
+    useAccount: () => {
+      return {
+        isConnected: true,
+      };
+    },
+  };
+});
+
 const initializeMixpanelAndEnable = () => {
   mixpanel.init(MIXPANEL_TOKEN_FOR_TEST, { ip: false });
   enableMixpanel();
 };
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterAll(() => server.close());
+
 beforeEach(() => {
   vi.spyOn(mixpanel, "init");
   vi.spyOn(mixpanel, "track");
   initializeMixpanelAndEnable();
 });
 afterEach(() => {
+  server.resetHandlers();
   cleanup();
 });

--- a/pages/governance/src/components/common/banners/banner-black.spec.tsx
+++ b/pages/governance/src/components/common/banners/banner-black.spec.tsx
@@ -1,7 +1,7 @@
 // Copyright Tharsis Labs Ltd.(Evmos)
 // SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
 
-import { test, describe, expect, vi } from "vitest";
+import { test, describe, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
@@ -14,24 +14,10 @@ import BannerBlack from "./BannerBlack";
 import { COMMONWEALTH_URL } from "constants-helper";
 
 import { RootProviders } from "stateful-components/src/root-providers";
-import { PropsWithChildren } from "react";
 import { MIXPANEL_TOKEN_FOR_TEST } from "../../../../vitest.setup";
 
 const TEXT = "Test";
 
-vi.mock("@tanstack/react-query-next-experimental", () => ({
-  ReactQueryStreamedHydration: (props: PropsWithChildren<{}>) => props.children,
-}));
-
-vi.mock(
-  "@evmosapps/evmos-wallet",
-  async (importOriginal: () => Promise<{}>) => {
-    return {
-      ...(await importOriginal()),
-      getActiveProviderKey: () => null,
-    };
-  },
-);
 describe("Testing Banner Black", () => {
   const wrapper = ({ children }: { children: JSX.Element }) => {
     return <RootProviders>{children}</RootProviders>;

--- a/pages/governance/src/components/governance/proposalPage/vote/vote-button.spec.tsx
+++ b/pages/governance/src/components/governance/proposalPage/vote/vote-button.spec.tsx
@@ -13,61 +13,10 @@ import {
 import { RootProviders } from "stateful-components/src/root-providers";
 
 import VoteButton from "./VoteButton";
-import { PropsWithChildren } from "react";
-import { MIXPANEL_TOKEN_FOR_TEST } from "../../../../../vitest.setup";
-import { getPercentage } from "helpers";
-
-vi.mock("@tanstack/react-query-next-experimental", () => ({
-  ReactQueryStreamedHydration: (props: PropsWithChildren<{}>) => props.children,
-}));
-
-vi.mock(
-  "@evmosapps/evmos-wallet",
-  async (importOriginal: () => Promise<{}>) => {
-    return {
-      ...(await importOriginal()),
-      getActiveProviderKey: () => null,
-    };
-  },
-);
-
-const ResizeObserver = vi.fn(() => ({
-  observe: vi.fn(),
-  unobserve: vi.fn(),
-  disconnect: vi.fn(),
-}));
-
-vi.mock("../../../../utils/hooks/useProposals", () => ({
-  useProposalById: () => ({
-    data: {
-      id: 1,
-      title: "title",
-
-      description: "description",
-
-      tally: getPercentage({
-        yes: "0",
-        no: "0",
-        abstain: "0",
-        noWithVeto: "0",
-      }),
-      tallyAbsolute: {
-        yes: "0",
-        no: "0",
-        abstain: "0",
-        noWithVeto: "0",
-      },
-      votingStart: new Date("Fri Jan 26 2024 16:40:04 GMT+0100"),
-      votingEnd: new Date("Fri Jan 26 2024 16:40:04 GMT+0100"),
-      depositEnd: new Date("Fri Jan 26 2024 16:40:04 GMT+0100"),
-      submitTime: new Date("Fri Jan 26 2024 16:40:04 GMT+0100"),
-      totalVotes: 0n,
-      totalDeposit: "0",
-
-      type: "",
-    },
-  }),
-}));
+import {
+  MIXPANEL_TOKEN_FOR_TEST,
+  ResizeObserver,
+} from "../../../../../vitest.setup";
 
 describe("Testing Container Proposals", () => {
   const wrapper = ({ children }: { children: JSX.Element }) => {
@@ -76,7 +25,7 @@ describe("Testing Container Proposals", () => {
 
   test("should call mixpanel event for clicking on proposal Card", async () => {
     vi.stubGlobal("ResizeObserver", ResizeObserver);
-    render(<VoteButton proposalId="267" />, {
+    render(<VoteButton proposalId="2" />, {
       wrapper,
     });
     const button = await screen.findByRole("button", { name: "Vote" });
@@ -95,7 +44,7 @@ describe("Testing Container Proposals", () => {
   test("should call mixpanel event for clicking on proposal Card", async () => {
     disableMixpanel();
     vi.stubGlobal("ResizeObserver", ResizeObserver);
-    render(<VoteButton proposalId="1" />, {
+    render(<VoteButton proposalId="2" />, {
       wrapper,
     });
     const button = await screen.findByRole("button", { name: "Vote" });

--- a/pages/governance/src/components/governance/proposals/container-proposals.spec.tsx
+++ b/pages/governance/src/components/governance/proposals/container-proposals.spec.tsx
@@ -1,7 +1,7 @@
 // Copyright Tharsis Labs Ltd.(Evmos)
 // SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
 
-import { test, describe, vi, expect } from "vitest";
+import { test, describe, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
@@ -11,76 +11,23 @@ import {
   localMixpanel as mixpanel,
 } from "tracker";
 import { RootProviders } from "stateful-components/src/root-providers";
-import { PropsWithChildren } from "react";
 import { MIXPANEL_TOKEN_FOR_TEST } from "../../../../vitest.setup";
 import { ContainerProposals } from "./ContainerProposals";
-import { getPercentage } from "helpers";
 
-vi.mock(
-  "@evmosapps/evmos-wallet",
-  async (importOriginal: () => Promise<{}>) => {
-    return {
-      ...(await importOriginal()),
-      getActiveProviderKey: () => null,
-    };
-  },
-);
-
-vi.mock("@tanstack/react-query-next-experimental", () => ({
-  ReactQueryStreamedHydration: (props: PropsWithChildren<{}>) => props.children,
-}));
-
-vi.mock("../../../utils/hooks/useProposals", () => ({
-  useProposals: () => ({
-    data: [
-      {
-        id: 1,
-        title: "title",
-
-        description: "description",
-
-        tally: getPercentage({
-          yes: "0",
-          no: "0",
-          abstain: "0",
-          noWithVeto: "0",
-        }),
-        tallyAbsolute: {
-          yes: "0",
-          no: "0",
-          abstain: "0",
-          noWithVeto: "0",
-        },
-        votingStart:
-          "Fri Jan 26 2024 16:40:04 GMT+0100 (Central European Standard Time)",
-        votingEnd:
-          "Fri Jan 26 2024 16:40:04 GMT+0100 (Central European Standard Time)",
-        depositEnd:
-          "Fri Jan 26 2024 16:40:04 GMT+0100 (Central European Standard Time)",
-        submitTime:
-          "Fri Jan 26 2024 16:40:04 GMT+0100 (Central European Standard Time)",
-        totalVotes: 0n,
-        totalDeposit: "0",
-
-        type: "",
-      },
-    ],
-  }),
-}));
 describe("Testing Container Proposals", () => {
   const wrapper = ({ children }: { children: JSX.Element }) => {
     return <RootProviders>{children}</RootProviders>;
   };
   test("should call mixpanel event for clicking on proposal Card", async () => {
     render(<ContainerProposals />, { wrapper });
-    const button = await screen.findByText(/title/i);
+    const button = await screen.findByText(/Governance Proposal Mission/i);
     expect(button).toBeDefined();
     await userEvent.click(button);
     expect(mixpanel.init).toHaveBeenCalledOnce();
     expect(mixpanel.track).toHaveBeenCalledWith(CLICK_GOVERNANCE_PROPOSAL, {
       "User Wallet Address": undefined,
       "Wallet Provider": null,
-      "Governance Proposal": 1,
+      "Governance Proposal": "2",
       token: MIXPANEL_TOKEN_FOR_TEST,
     });
   });
@@ -88,7 +35,7 @@ describe("Testing Container Proposals", () => {
   test("should not call mixpanel event for clicking on proposal Card", async () => {
     disableMixpanel();
     render(<ContainerProposals />, { wrapper });
-    const button = screen.getByText(/title/i);
+    const button = screen.getByText(/Governance Proposal Mission/i);
     expect(button).toBeDefined();
     await userEvent.click(button);
     expect(mixpanel.init).toHaveBeenCalledOnce();

--- a/pages/governance/src/mocks/handlers.ts
+++ b/pages/governance/src/mocks/handlers.ts
@@ -1,0 +1,84 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
+
+import { http, HttpResponse } from "msw";
+
+export const handlers = [
+  http.get("/api/cosmos-rest/evmos/cosmos/gov/v1/proposals", () => {
+    return HttpResponse.json(
+      {
+        proposals: [
+          {
+            id: "1",
+            messages: [
+              {
+                "@type": "/cosmos.gov.v1.MsgExecLegacyContent",
+                content: {
+                  "@type": "/cosmos.gov.v1beta1.TextProposal",
+                  title: "Airdrop Claim Mission",
+                  description: "Vote to claim",
+                },
+                // eslint-disable-next-line no-secrets/no-secrets
+                authority: "evmos10d07y265gmmuvt4z0w9aw880jnsr700jcrztvm",
+              },
+            ],
+            status: "PROPOSAL_STATUS_PASSED",
+            final_tally_result: {
+              yes_count: "5572621435466967266761313",
+              abstain_count: "155119544168132378159044",
+              no_count: "41434192570722978028892",
+              no_with_veto_count: "11160632020957358092220",
+            },
+            submit_time: "2022-03-03T19:18:21.382288871Z",
+            deposit_end_time: "2022-03-17T19:18:21.382288871Z",
+            total_deposit: [
+              { denom: "aevmos", amount: "10000000000000000000" },
+            ],
+            voting_start_time: "2022-03-03T19:18:21.382288871Z",
+            voting_end_time: "2022-03-08T19:18:21.382288871Z",
+            metadata: "",
+            title: "",
+            summary: "",
+            proposer: "",
+          },
+          {
+            id: "2",
+            messages: [
+              {
+                "@type": "/cosmos.gov.v1.MsgExecLegacyContent",
+                content: {
+                  "@type": "/cosmos.gov.v1beta1.TextProposal",
+                  title: "Governance Proposal Mission",
+                  description: "brought to your by validator - evmosius",
+                },
+                // eslint-disable-next-line no-secrets/no-secrets
+                authority: "evmos10d07y265gmmuvt4z0w9aw880jnsr700jcrztvm",
+              },
+            ],
+            status: "PROPOSAL_STATUS_PASSED",
+            final_tally_result: {
+              yes_count: "2907459863780634741296844",
+              abstain_count: "1602116275035023558974919",
+              no_count: "9861714168941468106064",
+              no_with_veto_count: "10594184632343164499631",
+            },
+            submit_time: "2022-04-29T16:11:44.657781538Z",
+            deposit_end_time: "2022-05-13T16:11:44.657781538Z",
+            total_deposit: [
+              { denom: "aevmos", amount: "12365243000001000000" },
+            ],
+            voting_start_time: "2022-04-29T16:40:46.963770634Z",
+            voting_end_time: "2022-05-04T16:40:46.963770634Z",
+            metadata: "",
+            title: "",
+            summary: "",
+            proposer: "",
+          },
+        ],
+        pagination: { next_key: "AAAAAAAAAHM=", total: "173" },
+      },
+
+      { status: 200 },
+    );
+  }),
+];

--- a/pages/governance/src/mocks/server.ts
+++ b/pages/governance/src/mocks/server.ts
@@ -1,0 +1,7 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
+
+import { setupServer } from "msw/node";
+import { handlers } from "./handlers";
+
+export const server = setupServer(...handlers);

--- a/pages/governance/vitest.setup.ts
+++ b/pages/governance/vitest.setup.ts
@@ -2,18 +2,46 @@
 // SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
 
 import { cleanup } from "@testing-library/react";
-import { afterEach, beforeEach, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, vi } from "vitest";
 import { enableMixpanel, localMixpanel as mixpanel } from "tracker";
+import { PropsWithChildren } from "react";
+import { server } from "./src/mocks/server";
+
 export const MIXPANEL_TOKEN_FOR_TEST = "testToken";
 const initializeMixpanelAndEnable = () => {
   mixpanel.init(MIXPANEL_TOKEN_FOR_TEST, { ip: false });
   enableMixpanel();
 };
+
+vi.mock(
+  "@evmosapps/evmos-wallet",
+  async (importOriginal: () => Promise<{}>) => {
+    return {
+      ...(await importOriginal()),
+      getActiveProviderKey: () => null,
+    };
+  },
+);
+
+vi.mock("@tanstack/react-query-next-experimental", () => ({
+  ReactQueryStreamedHydration: (props: PropsWithChildren<{}>) => props.children,
+}));
+
+export const ResizeObserver = vi.fn(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+}));
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterAll(() => server.close());
+
 beforeEach(() => {
   vi.spyOn(mixpanel, "init");
   vi.spyOn(mixpanel, "track");
   initializeMixpanelAndEnable();
 });
 afterEach(() => {
+  server.resetHandlers();
   cleanup();
 });

--- a/pages/portfolio/mocks/handlers.ts
+++ b/pages/portfolio/mocks/handlers.ts
@@ -1,0 +1,84 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
+
+import { http, HttpResponse } from "msw";
+
+export const handlers = [
+  http.get("/api/cosmos-rest/evmos/cosmos/gov/v1/proposals", () => {
+    return HttpResponse.json(
+      {
+        proposals: [
+          {
+            id: "1",
+            messages: [
+              {
+                "@type": "/cosmos.gov.v1.MsgExecLegacyContent",
+                content: {
+                  "@type": "/cosmos.gov.v1beta1.TextProposal",
+                  title: "Airdrop Claim Mission",
+                  description: "Vote to claim",
+                },
+                // eslint-disable-next-line no-secrets/no-secrets
+                authority: "evmos10d07y265gmmuvt4z0w9aw880jnsr700jcrztvm",
+              },
+            ],
+            status: "PROPOSAL_STATUS_PASSED",
+            final_tally_result: {
+              yes_count: "5572621435466967266761313",
+              abstain_count: "155119544168132378159044",
+              no_count: "41434192570722978028892",
+              no_with_veto_count: "11160632020957358092220",
+            },
+            submit_time: "2022-03-03T19:18:21.382288871Z",
+            deposit_end_time: "2022-03-17T19:18:21.382288871Z",
+            total_deposit: [
+              { denom: "aevmos", amount: "10000000000000000000" },
+            ],
+            voting_start_time: "2022-03-03T19:18:21.382288871Z",
+            voting_end_time: "2022-03-08T19:18:21.382288871Z",
+            metadata: "",
+            title: "",
+            summary: "",
+            proposer: "",
+          },
+          {
+            id: "2",
+            messages: [
+              {
+                "@type": "/cosmos.gov.v1.MsgExecLegacyContent",
+                content: {
+                  "@type": "/cosmos.gov.v1beta1.TextProposal",
+                  title: "Governance Proposal Mission",
+                  description: "brought to your by validator - evmosius",
+                },
+                // eslint-disable-next-line no-secrets/no-secrets
+                authority: "evmos10d07y265gmmuvt4z0w9aw880jnsr700jcrztvm",
+              },
+            ],
+            status: "PROPOSAL_STATUS_PASSED",
+            final_tally_result: {
+              yes_count: "2907459863780634741296844",
+              abstain_count: "1602116275035023558974919",
+              no_count: "9861714168941468106064",
+              no_with_veto_count: "10594184632343164499631",
+            },
+            submit_time: "2022-04-29T16:11:44.657781538Z",
+            deposit_end_time: "2022-05-13T16:11:44.657781538Z",
+            total_deposit: [
+              { denom: "aevmos", amount: "12365243000001000000" },
+            ],
+            voting_start_time: "2022-04-29T16:40:46.963770634Z",
+            voting_end_time: "2022-05-04T16:40:46.963770634Z",
+            metadata: "",
+            title: "",
+            summary: "",
+            proposer: "",
+          },
+        ],
+        pagination: { next_key: "AAAAAAAAAHM=", total: "173" },
+      },
+
+      { status: 200 },
+    );
+  }),
+];

--- a/pages/portfolio/mocks/server.ts
+++ b/pages/portfolio/mocks/server.ts
@@ -1,0 +1,7 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
+
+import { setupServer } from "msw/node";
+import { handlers } from "./handlers";
+
+export const server = setupServer(...handlers);

--- a/pages/portfolio/src/asset/table/assets-table.spec.tsx
+++ b/pages/portfolio/src/asset/table/assets-table.spec.tsx
@@ -1,7 +1,7 @@
 // Copyright Tharsis Labs Ltd.(Evmos)
 // SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
 
-import { test, describe, expect, vi } from "vitest";
+import { test, describe, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
@@ -12,31 +12,9 @@ import {
 } from "tracker";
 
 import { RootProviders } from "stateful-components/src/root-providers";
-import { PropsWithChildren } from "react";
 import AssetsTable from "./AssetsTable";
 import { MIXPANEL_TOKEN_FOR_TEST } from "../../../vitest.setup";
 
-vi.mock("@tanstack/react-query-next-experimental", () => ({
-  ReactQueryStreamedHydration: (props: PropsWithChildren<{}>) => props.children,
-}));
-vi.mock("react", async (importOriginal: () => Promise<{}>) => {
-  return {
-    ...(await importOriginal()),
-
-    cache: (fn: unknown) => fn,
-    "server-only": {},
-  };
-});
-
-vi.mock(
-  "@evmosapps/evmos-wallet",
-  async (importOriginal: () => Promise<{}>) => {
-    return {
-      ...(await importOriginal()),
-      getActiveProviderKey: () => null,
-    };
-  },
-);
 describe("Testing Assets Table", () => {
   const wrapper = ({ children }: { children: JSX.Element }) => {
     return <RootProviders>{children}</RootProviders>;

--- a/pages/portfolio/src/asset/table/components/subrow-content.spec.tsx
+++ b/pages/portfolio/src/asset/table/components/subrow-content.spec.tsx
@@ -12,7 +12,6 @@ import {
 import { SubRowContent } from "./SubRowContent";
 import { BigNumber } from "@ethersproject/bignumber";
 import { RootProviders } from "stateful-components/src/root-providers";
-import { PropsWithChildren } from "react";
 import { MIXPANEL_TOKEN_FOR_TEST } from "../../../../vitest.setup";
 
 const MOCKED_TOKEN = {
@@ -33,16 +32,6 @@ const MOCKED_TOKEN = {
     "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gweth.png",
   prefix: "gravity",
 };
-vi.mock("@tanstack/react-query-next-experimental", () => ({
-  ReactQueryStreamedHydration: (props: PropsWithChildren<{}>) => props.children,
-}));
-
-vi.mock("react", async (importOriginal: () => Promise<{}>) => {
-  return {
-    ...(await importOriginal()),
-    cache: (fn: unknown) => fn,
-  };
-});
 describe("Testing Tab Nav Item ", () => {
   const wrapper = ({ children }: { children: JSX.Element }) => {
     return <RootProviders>{children}</RootProviders>;

--- a/pages/portfolio/src/asset/table/topBar/topbar.spec.tsx
+++ b/pages/portfolio/src/asset/table/topBar/topbar.spec.tsx
@@ -1,88 +1,31 @@
 // Copyright Tharsis Labs Ltd.(Evmos)
 // SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
 
-import { test, describe, expect, vi } from "vitest";
+import { test, describe, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import { BigNumber } from "@ethersproject/bignumber";
 import {
   CLICK_ON_RECEIVE_BUTTON,
   CLICK_ON_SEND_BUTTON,
   disableMixpanel,
   localMixpanel as mixpanel,
 } from "tracker";
-
 import { RootProviders } from "stateful-components/src/root-providers";
-import { PropsWithChildren } from "react";
 import TopBar from "./TopBar";
-import { MIXPANEL_TOKEN_FOR_TEST } from "../../../../vitest.setup";
+import {
+  TEST_ADDRESS,
+  MIXPANEL_TOKEN_FOR_TEST,
+  TEST_TOP_BAR_PROPS,
+} from "../../../../vitest.setup";
 
-const TOP_BAR_PROPS = {
-  totalAssets: "1",
-  evmosPrice: 1,
-  setIsOpen: vi.fn(),
-  setModalContent: vi.fn(),
-  tableData: {
-    table: [],
-    feeBalance: BigNumber.from(1),
-  },
-};
-
-const ADDRESS = "0xaf3219826cb708463b3aa3b73c6640a21497ae49";
-
-vi.mock("@tanstack/react-query-next-experimental", () => ({
-  ReactQueryStreamedHydration: (props: PropsWithChildren<{}>) => props.children,
-}));
-
-vi.mock("wagmi", async (importOriginal: () => Promise<{}>) => {
-  return {
-    ...(await importOriginal()),
-    useAccount: () => {
-      return {
-        isDisconnected: false,
-        address: ADDRESS,
-      };
-    },
-  };
-});
-
-vi.mock("wagmi/actions", async (importOriginal: () => Promise<{}>) => {
-  return {
-    ...(await importOriginal()),
-    getAccount: () => {
-      return {
-        connector: {
-          id: "metaMask",
-        },
-      };
-    },
-  };
-});
-
-vi.mock("react", async (importOriginal: () => Promise<{}>) => {
-  return {
-    ...(await importOriginal()),
-    cache: (fn: unknown) => fn,
-  };
-});
-
-vi.mock(
-  "@evmosapps/evmos-wallet",
-  async (importOriginal: () => Promise<{}>) => {
-    return {
-      ...(await importOriginal()),
-      getActiveProviderKey: () => null,
-    };
-  },
-);
 describe("Testing Top bar Portfolio", () => {
   const wrapper = ({ children }: { children: JSX.Element }) => {
     return <RootProviders>{children}</RootProviders>;
   };
 
   test("should call mixpanel event for start send", async () => {
-    render(<TopBar topProps={TOP_BAR_PROPS} />, {
+    render(<TopBar topProps={TEST_TOP_BAR_PROPS} />, {
       wrapper,
     });
     const button = await screen.findByTestId(/open-send-modal-button/i);
@@ -90,7 +33,7 @@ describe("Testing Top bar Portfolio", () => {
     await userEvent.click(button);
     expect(mixpanel.init).toHaveBeenCalledOnce();
     expect(mixpanel.track).toHaveBeenCalledWith(CLICK_ON_SEND_BUTTON, {
-      "User Wallet Address": ADDRESS,
+      "User Wallet Address": TEST_ADDRESS,
       "Wallet Provider": "metaMask",
       token: MIXPANEL_TOKEN_FOR_TEST,
     });
@@ -98,7 +41,7 @@ describe("Testing Top bar Portfolio", () => {
 
   test("should not call mixpanel event for start send", async () => {
     disableMixpanel();
-    render(<TopBar topProps={TOP_BAR_PROPS} />, {
+    render(<TopBar topProps={TEST_TOP_BAR_PROPS} />, {
       wrapper,
     });
     const button = await screen.findByTestId(/open-send-modal-button/i);
@@ -109,7 +52,7 @@ describe("Testing Top bar Portfolio", () => {
   });
 
   test("should call mixpanel event for start request", async () => {
-    render(<TopBar topProps={TOP_BAR_PROPS} />, {
+    render(<TopBar topProps={TEST_TOP_BAR_PROPS} />, {
       wrapper,
     });
     const button = await screen.findByTestId(/open-request-modal-button/i);
@@ -117,7 +60,7 @@ describe("Testing Top bar Portfolio", () => {
     await userEvent.click(button);
     expect(mixpanel.init).toHaveBeenCalledOnce();
     expect(mixpanel.track).toHaveBeenCalledWith(CLICK_ON_RECEIVE_BUTTON, {
-      "User Wallet Address": ADDRESS,
+      "User Wallet Address": TEST_ADDRESS,
       "Wallet Provider": "metaMask",
       token: MIXPANEL_TOKEN_FOR_TEST,
     });
@@ -125,7 +68,7 @@ describe("Testing Top bar Portfolio", () => {
 
   test("should not call mixpanel event for start request", async () => {
     disableMixpanel();
-    render(<TopBar topProps={TOP_BAR_PROPS} />, {
+    render(<TopBar topProps={TEST_TOP_BAR_PROPS} />, {
       wrapper,
     });
     const button = await screen.findByTestId(/open-request-modal-button/i);

--- a/pages/portfolio/src/modals/pay/content.spec.tsx
+++ b/pages/portfolio/src/modals/pay/content.spec.tsx
@@ -12,62 +12,8 @@ import {
 } from "tracker";
 
 import { RootProviders } from "stateful-components/src/root-providers";
-import { PropsWithChildren } from "react";
 import { Content } from "./Content";
 import { MIXPANEL_TOKEN_FOR_TEST } from "../../../vitest.setup";
-
-// eslint-disable-next-line no-secrets/no-secrets
-const ADDRESS = "evmos1c8wgcmqde5jzymrjrflpp8j20ss000c00zd0ak";
-
-vi.mock("@tanstack/react-query-next-experimental", () => ({
-  ReactQueryStreamedHydration: (props: PropsWithChildren<{}>) => props.children,
-}));
-
-vi.mock("react", async (importOriginal: () => Promise<{}>) => {
-  return {
-    ...(await importOriginal()),
-    cache: (fn: unknown) => fn,
-  };
-});
-
-vi.mock("wagmi", async (importOriginal: () => Promise<{}>) => {
-  return {
-    ...(await importOriginal()),
-    useAccount: () => {
-      return {
-        isDisconnected: false,
-        address: ADDRESS,
-        connector: {
-          id: "metaMask",
-        },
-      };
-    },
-  };
-});
-
-vi.mock(
-  "@evmosapps/evmos-wallet",
-  async (importOriginal: () => Promise<{}>) => {
-    return {
-      ...(await importOriginal()),
-      useFee: () => {
-        return {
-          fee: {
-            gasLimit: 1n,
-            token: "evmos:EVMOS",
-          },
-          isPending: false,
-        };
-      },
-      useTokenBalance: () => {
-        return {
-          balance: 1n,
-          isFetching: false,
-        };
-      },
-    };
-  },
-);
 
 describe("Testing Content Pay", () => {
   const wrapper = ({ children }: { children: JSX.Element }) => {

--- a/pages/portfolio/src/modals/request/receive-content.spec.tsx
+++ b/pages/portfolio/src/modals/request/receive-content.spec.tsx
@@ -13,46 +13,8 @@ import {
   localMixpanel as mixpanel,
 } from "tracker";
 import { RootProviders } from "stateful-components/src/root-providers";
-import { PropsWithChildren } from "react";
-
 import { ReceiveContent } from "./ReceiveContent";
 import { MIXPANEL_TOKEN_FOR_TEST } from "../../../vitest.setup";
-
-// eslint-disable-next-line no-secrets/no-secrets
-const ADDRESS = "0xC1dC8C6c0dCd24226c721a7E109E4A7C20F7bF0f";
-vi.mock("@tanstack/react-query-next-experimental", () => ({
-  ReactQueryStreamedHydration: (props: PropsWithChildren<{}>) => props.children,
-}));
-vi.mock("react", async (importOriginal: () => Promise<{}>) => {
-  return {
-    ...(await importOriginal()),
-
-    cache: (fn: unknown) => fn,
-    "server-only": {},
-  };
-});
-
-vi.mock("wagmi", async (importOriginal: () => Promise<{}>) => {
-  return {
-    ...(await importOriginal()),
-    useAccount: () => {
-      return {
-        isDisconnected: false,
-        address: ADDRESS,
-      };
-    },
-  };
-});
-
-vi.mock(
-  "@evmosapps/evmos-wallet",
-  async (importOriginal: () => Promise<{}>) => {
-    return {
-      ...(await importOriginal()),
-      getActiveProviderKey: () => null,
-    };
-  },
-);
 
 describe("Testing Receive Content", () => {
   const wrapper = ({ children }: { children: JSX.Element }) => {

--- a/pages/portfolio/src/modals/request/request-asset-selector.spec.tsx
+++ b/pages/portfolio/src/modals/request/request-asset-selector.spec.tsx
@@ -4,7 +4,6 @@
 import { test, describe, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-
 import {
   SELECT_FROM_NETWORK_SEND_FLOW,
   SELECT_TOKEN_SEND_FLOW,
@@ -12,25 +11,8 @@ import {
   localMixpanel as mixpanel,
 } from "tracker";
 import { RootProviders } from "stateful-components/src/root-providers";
-import { PropsWithChildren } from "react";
 import { RequestAssetSelector } from "./RequestAssetSelector";
-import { MIXPANEL_TOKEN_FOR_TEST } from "../../../vitest.setup";
-
-// eslint-disable-next-line no-secrets/no-secrets
-const ADDRESS = "evmos14uepnqnvkuyyvwe65wmncejq5g2f0tjft3wr65";
-vi.mock("@tanstack/react-query-next-experimental", () => ({
-  ReactQueryStreamedHydration: (props: PropsWithChildren<{}>) => props.children,
-}));
-
-vi.mock(
-  "@evmosapps/evmos-wallet",
-  async (importOriginal: () => Promise<{}>) => {
-    return {
-      ...(await importOriginal()),
-      getActiveProviderKey: () => null,
-    };
-  },
-);
+import { MIXPANEL_TOKEN_FOR_TEST, TEST_ADDRESS } from "../../../vitest.setup";
 
 describe("Testing Request Assets Selector", () => {
   const wrapper = ({ children }: { children: JSX.Element }) => {
@@ -46,7 +28,7 @@ describe("Testing Request Assets Selector", () => {
           amount: 0n,
         }}
         onChange={vi.fn()}
-        address={ADDRESS}
+        address={TEST_ADDRESS}
       />,
       {
         wrapper,
@@ -66,13 +48,13 @@ describe("Testing Request Assets Selector", () => {
     expect(mixpanel.init).toHaveBeenCalledOnce();
     expect(mixpanel.track).toHaveBeenCalledWith(SELECT_TOKEN_SEND_FLOW, {
       Token: "EVMOS",
-      "User Wallet Address": undefined,
+      "User Wallet Address": TEST_ADDRESS,
       "Wallet Provider": null,
       token: MIXPANEL_TOKEN_FOR_TEST,
     });
     expect(mixpanel.track).toHaveBeenCalledWith(SELECT_FROM_NETWORK_SEND_FLOW, {
       Network: "evmos",
-      "User Wallet Address": undefined,
+      "User Wallet Address": TEST_ADDRESS,
       "Wallet Provider": null,
       token: MIXPANEL_TOKEN_FOR_TEST,
     });
@@ -119,7 +101,7 @@ describe("Testing Request Assets Selector", () => {
           amount: 0n,
         }}
         onChange={vi.fn()}
-        address={ADDRESS}
+        address={TEST_ADDRESS}
       />,
       {
         wrapper,
@@ -138,7 +120,7 @@ describe("Testing Request Assets Selector", () => {
     expect(mixpanel.init).toHaveBeenCalledOnce();
     expect(mixpanel.track).toHaveBeenCalledWith(SELECT_FROM_NETWORK_SEND_FLOW, {
       Network: "evmos",
-      "User Wallet Address": undefined,
+      "User Wallet Address": TEST_ADDRESS,
       "Wallet Provider": null,
       token: MIXPANEL_TOKEN_FOR_TEST,
     });
@@ -155,7 +137,7 @@ describe("Testing Request Assets Selector", () => {
           amount: 0n,
         }}
         onChange={vi.fn()}
-        address={ADDRESS}
+        address={TEST_ADDRESS}
       />,
       {
         wrapper,

--- a/pages/portfolio/src/modals/request/setup-content.spec.tsx
+++ b/pages/portfolio/src/modals/request/setup-content.spec.tsx
@@ -10,45 +10,9 @@ import {
   localMixpanel as mixpanel,
 } from "tracker";
 import { RootProviders } from "stateful-components/src/root-providers";
-import { PropsWithChildren } from "react";
+
 import { SetUpContent } from "./SetupContent";
 import { MIXPANEL_TOKEN_FOR_TEST } from "../../../vitest.setup";
-
-// eslint-disable-next-line no-secrets/no-secrets
-const ADDRESS = "0xC1dC8C6c0dCd24226c721a7E109E4A7C20F7bF0f";
-vi.mock("@tanstack/react-query-next-experimental", () => ({
-  ReactQueryStreamedHydration: (props: PropsWithChildren<{}>) => props.children,
-}));
-vi.mock("react", async (importOriginal: () => Promise<{}>) => {
-  return {
-    ...(await importOriginal()),
-
-    cache: (fn: unknown) => fn,
-    "server-only": {},
-  };
-});
-
-vi.mock("wagmi", async (importOriginal: () => Promise<{}>) => {
-  return {
-    ...(await importOriginal()),
-    useAccount: () => {
-      return {
-        isDisconnected: false,
-        address: ADDRESS,
-      };
-    },
-  };
-});
-
-vi.mock(
-  "@evmosapps/evmos-wallet",
-  async (importOriginal: () => Promise<{}>) => {
-    return {
-      ...(await importOriginal()),
-      getActiveProviderKey: () => null,
-    };
-  },
-);
 
 describe("Testing Set Up Content", () => {
   const wrapper = ({ children }: { children: JSX.Element }) => {

--- a/pages/portfolio/src/modals/request/share-content.spec.tsx
+++ b/pages/portfolio/src/modals/request/share-content.spec.tsx
@@ -12,42 +12,8 @@ import {
   localMixpanel as mixpanel,
 } from "tracker";
 import { RootProviders } from "stateful-components/src/root-providers";
-import { PropsWithChildren } from "react";
 import { ShareContent } from "./ShareContent";
 import { MIXPANEL_TOKEN_FOR_TEST } from "../../../vitest.setup";
-
-vi.mock("@tanstack/react-query-next-experimental", () => ({
-  ReactQueryStreamedHydration: (props: PropsWithChildren<{}>) => props.children,
-}));
-vi.mock("react", async (importOriginal: () => Promise<{}>) => {
-  return {
-    ...(await importOriginal()),
-
-    cache: (fn: unknown) => fn,
-    "server-only": {},
-  };
-});
-
-vi.mock("wagmi", async (importOriginal: () => Promise<{}>) => {
-  return {
-    ...(await importOriginal()),
-    useAccount: () => {
-      return {
-        isDisconnected: false,
-      };
-    },
-  };
-});
-
-vi.mock(
-  "@evmosapps/evmos-wallet",
-  async (importOriginal: () => Promise<{}>) => {
-    return {
-      ...(await importOriginal()),
-      getActiveProviderKey: () => null,
-    };
-  },
-);
 
 describe("Testing Set Up Content", () => {
   const wrapper = ({ children }: { children: JSX.Element }) => {

--- a/pages/portfolio/src/modals/shared/account-selector.spec.tsx
+++ b/pages/portfolio/src/modals/shared/account-selector.spec.tsx
@@ -11,23 +11,9 @@ import {
   localMixpanel as mixpanel,
 } from "tracker";
 import { RootProviders } from "stateful-components/src/root-providers";
-import { PropsWithChildren } from "react";
+
 import { AccountSelector } from "./AccountSelector";
-import { MIXPANEL_TOKEN_FOR_TEST } from "../../../vitest.setup";
-
-vi.mock("@tanstack/react-query-next-experimental", () => ({
-  ReactQueryStreamedHydration: (props: PropsWithChildren<{}>) => props.children,
-}));
-
-vi.mock(
-  "@evmosapps/evmos-wallet",
-  async (importOriginal: () => Promise<{}>) => {
-    return {
-      ...(await importOriginal()),
-      getActiveProviderKey: () => null,
-    };
-  },
-);
+import { MIXPANEL_TOKEN_FOR_TEST, TEST_ADDRESS } from "../../../vitest.setup";
 
 describe("Testing Account Selector", () => {
   const wrapper = ({ children }: { children: JSX.Element }) => {
@@ -58,7 +44,7 @@ describe("Testing Account Selector", () => {
     expect(mixpanel.init).toHaveBeenCalledOnce();
     expect(mixpanel.track).toHaveBeenCalledWith(SELECT_TO_NETWORK_SEND_FLOW, {
       Network: "evmos",
-      "User Wallet Address": undefined,
+      "User Wallet Address": TEST_ADDRESS,
       "Wallet Provider": null,
       token: MIXPANEL_TOKEN_FOR_TEST,
     });

--- a/pages/portfolio/src/modals/shared/asset-selector.spec.tsx
+++ b/pages/portfolio/src/modals/shared/asset-selector.spec.tsx
@@ -12,25 +12,8 @@ import {
   localMixpanel as mixpanel,
 } from "tracker";
 import { RootProviders } from "stateful-components/src/root-providers";
-import { PropsWithChildren } from "react";
 import { AssetSelector } from "./AssetSelector";
-import { MIXPANEL_TOKEN_FOR_TEST } from "../../../vitest.setup";
-
-// eslint-disable-next-line no-secrets/no-secrets
-const ADDRESS = "evmos14uepnqnvkuyyvwe65wmncejq5g2f0tjft3wr65";
-vi.mock("@tanstack/react-query-next-experimental", () => ({
-  ReactQueryStreamedHydration: (props: PropsWithChildren<{}>) => props.children,
-}));
-
-vi.mock(
-  "@evmosapps/evmos-wallet",
-  async (importOriginal: () => Promise<{}>) => {
-    return {
-      ...(await importOriginal()),
-      getActiveProviderKey: () => null,
-    };
-  },
-);
+import { MIXPANEL_TOKEN_FOR_TEST, TEST_ADDRESS } from "../../../vitest.setup";
 
 describe("Testing Assets Selector", () => {
   const wrapper = ({ children }: { children: JSX.Element }) => {
@@ -46,7 +29,7 @@ describe("Testing Assets Selector", () => {
           amount: 0n,
         }}
         onChange={vi.fn()}
-        address={ADDRESS}
+        address={TEST_ADDRESS}
       />,
       {
         wrapper,
@@ -66,13 +49,13 @@ describe("Testing Assets Selector", () => {
     expect(mixpanel.init).toHaveBeenCalledOnce();
     expect(mixpanel.track).toHaveBeenCalledWith(SELECT_TOKEN_SEND_FLOW, {
       Token: "EVMOS",
-      "User Wallet Address": undefined,
+      "User Wallet Address": TEST_ADDRESS,
       "Wallet Provider": null,
       token: MIXPANEL_TOKEN_FOR_TEST,
     });
     expect(mixpanel.track).toHaveBeenCalledWith(SELECT_FROM_NETWORK_SEND_FLOW, {
       Network: "evmos",
-      "User Wallet Address": undefined,
+      "User Wallet Address": TEST_ADDRESS,
       "Wallet Provider": null,
       token: MIXPANEL_TOKEN_FOR_TEST,
     });
@@ -89,7 +72,7 @@ describe("Testing Assets Selector", () => {
           amount: 0n,
         }}
         onChange={vi.fn()}
-        address={ADDRESS}
+        address={TEST_ADDRESS}
       />,
       {
         wrapper,
@@ -119,7 +102,7 @@ describe("Testing Assets Selector", () => {
           amount: 0n,
         }}
         onChange={vi.fn()}
-        address={ADDRESS}
+        address={TEST_ADDRESS}
       />,
       {
         wrapper,
@@ -140,7 +123,7 @@ describe("Testing Assets Selector", () => {
     expect(mixpanel.init).toHaveBeenCalledOnce();
     expect(mixpanel.track).toHaveBeenCalledWith(SELECT_FROM_NETWORK_SEND_FLOW, {
       Network: "evmos",
-      "User Wallet Address": undefined,
+      "User Wallet Address": TEST_ADDRESS,
       "Wallet Provider": null,
       token: MIXPANEL_TOKEN_FOR_TEST,
     });
@@ -157,7 +140,7 @@ describe("Testing Assets Selector", () => {
           amount: 0n,
         }}
         onChange={vi.fn()}
-        address={ADDRESS}
+        address={TEST_ADDRESS}
       />,
       {
         wrapper,

--- a/pages/portfolio/src/modals/shared/connect-to-wallet-warning.spec.tsx
+++ b/pages/portfolio/src/modals/shared/connect-to-wallet-warning.spec.tsx
@@ -1,7 +1,7 @@
 // Copyright Tharsis Labs Ltd.(Evmos)
 // SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
 
-import { test, describe, expect, vi } from "vitest";
+import { test, describe, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
@@ -10,21 +10,9 @@ import {
   disableMixpanel,
   localMixpanel as mixpanel,
 } from "tracker";
-import { PropsWithChildren } from "react";
 import { ConnectToWalletWarning } from "./ConnectToWalletWarning";
 import { MIXPANEL_TOKEN_FOR_TEST } from "../../../vitest.setup";
 
-vi.mock("@tanstack/react-query-next-experimental", () => ({
-  ReactQueryStreamedHydration: (props: PropsWithChildren<{}>) => props.children,
-}));
-
-vi.mock("react", async (importOriginal: () => Promise<{}>) => {
-  return {
-    ...(await importOriginal()),
-    cache: (fn: unknown) => fn,
-    "server-only": {},
-  };
-});
 describe("Testing Connect To Wallet Warning", () => {
   test("should call mixpanel event for connect in pay modal", async () => {
     render(<ConnectToWalletWarning modalType="Pay Modal" />);

--- a/pages/portfolio/src/modals/transfer/transfer-modal-content.spec.tsx
+++ b/pages/portfolio/src/modals/transfer/transfer-modal-content.spec.tsx
@@ -10,72 +10,9 @@ import {
   disableMixpanel,
   localMixpanel as mixpanel,
 } from "tracker";
-import { PropsWithChildren } from "react";
 import { TransferModalContent } from "./TransferModalContent";
 import { RootProviders } from "stateful-components/src/root-providers";
-import { MIXPANEL_TOKEN_FOR_TEST } from "../../../vitest.setup";
-
-vi.mock("@tanstack/react-query-next-experimental", () => ({
-  ReactQueryStreamedHydration: (props: PropsWithChildren<{}>) => props.children,
-}));
-
-vi.mock("react", async (importOriginal: () => Promise<{}>) => {
-  return {
-    ...(await importOriginal()),
-    cache: (fn: unknown) => fn,
-    "server-only": {},
-  };
-});
-// eslint-disable-next-line no-secrets/no-secrets
-const RECEIVER = "evmos1c8wgcmqde5jzymrjrflpp8j20ss000c00zd0ak";
-vi.mock("wagmi", async (importOriginal: () => Promise<{}>) => {
-  return {
-    ...(await importOriginal()),
-    useAccount: () => {
-      return {
-        isDisconnected: false,
-        address: RECEIVER,
-      };
-    },
-  };
-});
-
-vi.mock("wagmi/actions", async (importOriginal: () => Promise<{}>) => {
-  return {
-    ...(await importOriginal()),
-    getAccount: () => {
-      return {
-        connector: {
-          id: "metaMask",
-        },
-      };
-    },
-  };
-});
-
-vi.mock(
-  "@evmosapps/evmos-wallet",
-  async (importOriginal: () => Promise<{}>) => {
-    return {
-      ...(await importOriginal()),
-      useFee: () => {
-        return {
-          fee: {
-            gasLimit: 1n,
-            token: "evmos:EVMOS",
-          },
-          isPending: false,
-        };
-      },
-      useTokenBalance: () => {
-        return {
-          balance: 1n,
-          isFetching: false,
-        };
-      },
-    };
-  },
-);
+import { MIXPANEL_TOKEN_FOR_TEST, TEST_ADDRESS } from "../../../vitest.setup";
 
 describe("Testing Transfer Modal Content", () => {
   const wrapper = ({ children }: { children: JSX.Element }) => {
@@ -85,7 +22,7 @@ describe("Testing Transfer Modal Content", () => {
   test("should call mixpanel event for top up in send modal", async () => {
     render(
       <TransferModalContent
-        receiver={RECEIVER}
+        receiver={TEST_ADDRESS}
         networkPrefix="evmos"
         token="evmos:EVMOS"
         amount={1n}
@@ -108,7 +45,7 @@ describe("Testing Transfer Modal Content", () => {
   test("should call mixpanel event for satellite ", async () => {
     render(
       <TransferModalContent
-        receiver={RECEIVER}
+        receiver={TEST_ADDRESS}
         networkPrefix="axelar"
         token="axelar:axlUSDC"
         amount={1n}
@@ -134,7 +71,7 @@ describe("Testing Transfer Modal Content", () => {
   test("should call mixpanel event for connect with keplr", async () => {
     render(
       <TransferModalContent
-        receiver={RECEIVER}
+        receiver={TEST_ADDRESS}
         networkPrefix="axelar"
         token="evmos:EVMOS"
         amount={1n}
@@ -161,7 +98,7 @@ describe("Testing Transfer Modal Content", () => {
     disableMixpanel();
     render(
       <TransferModalContent
-        receiver={RECEIVER}
+        receiver={TEST_ADDRESS}
         networkPrefix="evmos"
         token="evmos:EVMOS"
         amount={1n}
@@ -181,7 +118,7 @@ describe("Testing Transfer Modal Content", () => {
     disableMixpanel();
     render(
       <TransferModalContent
-        receiver={RECEIVER}
+        receiver={TEST_ADDRESS}
         networkPrefix="axelar"
         token="axelar:axlUSDC"
         amount={1n}
@@ -203,7 +140,7 @@ describe("Testing Transfer Modal Content", () => {
     disableMixpanel();
     render(
       <TransferModalContent
-        receiver={RECEIVER}
+        receiver={TEST_ADDRESS}
         networkPrefix="axelar"
         token="evmos:EVMOS"
         amount={1n}

--- a/pages/portfolio/vitest.setup.ts
+++ b/pages/portfolio/vitest.setup.ts
@@ -4,8 +4,83 @@
 import { cleanup } from "@testing-library/react";
 import { afterEach, beforeEach, vi } from "vitest";
 import { enableMixpanel, localMixpanel as mixpanel } from "tracker";
-
+import { BigNumber } from "@ethersproject/bignumber";
 export const MIXPANEL_TOKEN_FOR_TEST = "testToken";
+export const TEST_ADDRESS = "0xaf3219826cb708463b3aa3b73c6640a21497ae49";
+
+export const TEST_TOP_BAR_PROPS = {
+  totalAssets: "1",
+  evmosPrice: 1,
+  setIsOpen: vi.fn(),
+  setModalContent: vi.fn(),
+  tableData: {
+    table: [],
+    feeBalance: BigNumber.from(1),
+  },
+};
+vi.mock("@tanstack/react-query-next-experimental", () => ({
+  ReactQueryStreamedHydration: (props: React.PropsWithChildren<{}>) =>
+    props.children,
+}));
+vi.mock("react", async (importOriginal: () => Promise<{}>) => {
+  return {
+    ...(await importOriginal()),
+
+    cache: (fn: unknown) => fn,
+    "server-only": {},
+  };
+});
+
+vi.mock(
+  "@evmosapps/evmos-wallet",
+  async (importOriginal: () => Promise<{}>) => {
+    return {
+      ...(await importOriginal()),
+      getActiveProviderKey: () => null,
+      useFee: () => {
+        return {
+          fee: {
+            gasLimit: 1n,
+            token: "evmos:EVMOS",
+          },
+          isPending: false,
+        };
+      },
+      useTokenBalance: () => {
+        return {
+          balance: 1n,
+          isFetching: false,
+        };
+      },
+    };
+  },
+);
+
+vi.mock("wagmi", async (importOriginal: () => Promise<{}>) => {
+  return {
+    ...(await importOriginal()),
+    useAccount: () => {
+      return {
+        isDisconnected: false,
+        address: TEST_ADDRESS,
+      };
+    },
+  };
+});
+
+vi.mock("wagmi/actions", async (importOriginal: () => Promise<{}>) => {
+  return {
+    ...(await importOriginal()),
+    getAccount: () => {
+      return {
+        connector: {
+          id: "metaMask",
+        },
+      };
+    },
+  };
+});
+
 const initializeMixpanelAndEnable = () => {
   mixpanel.init(MIXPANEL_TOKEN_FOR_TEST, { ip: false });
   enableMixpanel();

--- a/pages/staking/mocks/handlers.ts
+++ b/pages/staking/mocks/handlers.ts
@@ -1,0 +1,19 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
+
+import { http, HttpResponse } from "msw";
+// eslint-disable-next-line no-secrets/no-secrets
+// "/cosmos/staking/v1beta1/delegations/evmos14uepnqnvkuyyvwe65wmncejq5g2f0tjft3wr65",
+// eslint-disable-next-line no-secrets/no-secrets
+// "/cosmos/staking/v1beta1/delegators/evmos14uepnqnvkuyyvwe65wmncejq5g2f0tjft3wr65/unbonding_delegations",
+// /cosmos/distribution/v1beta1/delegators/{delegator_address}/rewards
+// /cosmos/staking/v1beta1/validators
+export const handlers = [
+  http.get("", () => {
+    return HttpResponse.json(
+      { id: 1 },
+
+      { status: 200 },
+    );
+  }),
+];

--- a/pages/staking/mocks/server.ts
+++ b/pages/staking/mocks/server.ts
@@ -1,0 +1,7 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
+
+import { setupServer } from "msw/node";
+import { handlers } from "./handlers";
+
+export const server = setupServer(...handlers);

--- a/pages/staking/src/components/staking/AllTabs/undelegations.spec.tsx
+++ b/pages/staking/src/components/staking/AllTabs/undelegations.spec.tsx
@@ -11,13 +11,11 @@ import {
 } from "tracker";
 import Undelegations from "./Undelegations";
 import { RootProviders } from "stateful-components/src/root-providers";
-import { PropsWithChildren } from "react";
 import { SearchWrapper } from "../../context/SearchContext";
-import { MIXPANEL_TOKEN_FOR_TEST } from "../../../../vitest.setup";
-
-vi.mock("@tanstack/react-query-next-experimental", () => ({
-  ReactQueryStreamedHydration: (props: PropsWithChildren<{}>) => props.children,
-}));
+import {
+  MIXPANEL_TOKEN_FOR_TEST,
+  ResizeObserver,
+} from "../../../../vitest.setup";
 
 vi.mock("@evmosapps/evmos-wallet/src/api/useStake", () => ({
   useStakingInfo: () => {
@@ -113,12 +111,6 @@ vi.mock("@evmosapps/evmos-wallet/src/api/useStake", () => ({
   },
 }));
 describe("Testing Undelegations", () => {
-  const ResizeObserver = vi.fn(() => ({
-    observe: vi.fn(),
-    unobserve: vi.fn(),
-    disconnect: vi.fn(),
-  }));
-
   const wrapper = ({ children }: { children: JSX.Element }) => {
     return (
       <RootProviders>

--- a/pages/staking/src/components/staking/components/top-bar-staking.spec.tsx
+++ b/pages/staking/src/components/staking/components/top-bar-staking.spec.tsx
@@ -12,38 +12,9 @@ import {
   disableMixpanel,
   localMixpanel as mixpanel,
 } from "tracker";
-import { PropsWithChildren } from "react";
 import TopBarStaking from "./TopBarStaking";
 import { RootProviders } from "stateful-components/src/root-providers";
 import { MIXPANEL_TOKEN_FOR_TEST } from "../../../../vitest.setup";
-
-vi.mock("@tanstack/react-query-next-experimental", () => ({
-  ReactQueryStreamedHydration: (props: PropsWithChildren<{}>) => props.children,
-}));
-
-vi.mock("wagmi/actions", async (importOriginal: () => Promise<{}>) => {
-  return {
-    ...(await importOriginal()),
-    getNetwork: () => {
-      return {
-        chain: {
-          id: 9001,
-        },
-      };
-    },
-  };
-});
-
-vi.mock("wagmi", async (importOriginal: () => Promise<{}>) => {
-  return {
-    ...(await importOriginal()),
-    useAccount: () => {
-      return {
-        isDisconnected: false,
-      };
-    },
-  };
-});
 
 vi.mock("@evmosapps/evmos-wallet/src/api/useStake", () => ({
   useStakingInfo: () => {

--- a/pages/staking/src/components/staking/modals/staking.spec.tsx
+++ b/pages/staking/src/components/staking/modals/staking.spec.tsx
@@ -13,7 +13,6 @@ import {
 } from "tracker";
 import Staking from "./Staking";
 import { RootProviders } from "stateful-components/src/root-providers";
-import { PropsWithChildren } from "react";
 import { MIXPANEL_TOKEN_FOR_TEST } from "../../../../vitest.setup";
 
 const validator = {
@@ -25,10 +24,6 @@ const validator = {
   // eslint-disable-next-line no-secrets/no-secrets
   validatorAddress: "evmosvaloper1dgpv4leszpeg2jusx2xgyfnhdzghf3rf0qq22v",
 };
-
-vi.mock("@tanstack/react-query-next-experimental", () => ({
-  ReactQueryStreamedHydration: (props: PropsWithChildren<{}>) => props.children,
-}));
 
 describe("Testing Tab Dropdowns ", () => {
   const wrapper = ({ children }: { children: JSX.Element }) => {

--- a/pages/staking/vitest.setup.ts
+++ b/pages/staking/vitest.setup.ts
@@ -2,19 +2,65 @@
 // SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
 
 import { cleanup } from "@testing-library/react";
-import { afterEach, beforeEach, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, vi } from "vitest";
 import { enableMixpanel, localMixpanel as mixpanel } from "tracker";
-
+import { server } from "./mocks/server";
 export const MIXPANEL_TOKEN_FOR_TEST = "testToken";
+
+export const ResizeObserver = vi.fn(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+}));
+
+vi.mock("wagmi", async (importOriginal: () => Promise<{}>) => {
+  return {
+    ...(await importOriginal()),
+    useAccount: () => {
+      return {
+        isDisconnected: false,
+        // eslint-disable-next-line no-secrets/no-secrets
+        address: "evmos14uepnqnvkuyyvwe65wmncejq5g2f0tjft3wr65",
+        connector: {
+          id: "metaMask",
+        },
+      };
+    },
+  };
+});
+
+vi.mock("wagmi/actions", async (importOriginal: () => Promise<{}>) => {
+  return {
+    ...(await importOriginal()),
+    getNetwork: () => {
+      return {
+        chain: {
+          id: 9001,
+        },
+      };
+    },
+  };
+});
+
+vi.mock("@tanstack/react-query-next-experimental", () => ({
+  ReactQueryStreamedHydration: (props: React.PropsWithChildren<{}>) =>
+    props.children,
+}));
+
 const initializeMixpanelAndEnable = () => {
   mixpanel.init(MIXPANEL_TOKEN_FOR_TEST, { ip: false });
   enableMixpanel();
 };
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterAll(() => server.close());
+
 beforeEach(() => {
   vi.spyOn(mixpanel, "init");
   vi.spyOn(mixpanel, "track");
   initializeMixpanelAndEnable();
 });
 afterEach(() => {
+  server.resetHandlers();
   cleanup();
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       knip:
         specifier: 4.0.0-canary.8
         version: 4.0.0-canary.8(@types/node@20.11.5)(typescript@5.3.3)
+      msw:
+        specifier: ^2.1.5
+        version: 2.1.5(typescript@5.3.3)
       prettier:
         specifier: ^3.0.1
         version: 3.1.0
@@ -371,7 +374,7 @@ importers:
         version: link:../config
       vitest-canvas-mock:
         specifier: ^0.3.3
-        version: 0.3.3(vitest@1.1.3)
+        version: 0.3.3(vitest@1.2.2)
 
   packages/evmos-wallet:
     dependencies:
@@ -1208,7 +1211,7 @@ importers:
         version: link:../../packages/icons
       chainapsis-suggest-chain:
         specifier: github:chainapsis/keplr-chain-registry
-        version: github.com/chainapsis/keplr-chain-registry/58f56188f5b0d05a2858a018a19b14c102d262b7(@babel/core@7.23.7)(react-is@18.2.0)
+        version: github.com/chainapsis/keplr-chain-registry/eb0c68c27346f03388f2797a151cae1e830cf2bb(@babel/core@7.23.7)(react-is@18.2.0)
       ethers:
         specifier: ^6.9.2
         version: 6.9.2
@@ -2913,6 +2916,18 @@ packages:
 
   /@bufbuild/protobuf@1.6.0:
     resolution: {integrity: sha512-hp19vSFgNw3wBBcVBx5qo5pufCqjaJ0Cfk5H/pfjNOfNWU+4/w0QVOmfAOZNRrNWRrVuaJWxcN8P2vhOkkzbBQ==}
+
+  /@bundled-es-modules/cookie@2.0.0:
+    resolution: {integrity: sha512-Or6YHg/kamKHpxULAdSqhGqnWFneIXu1NKvvfBBzKGwpVsYuFIQ5aBPHDnnoR3ghW1nvSkALd+EF9iMtY7Vjxw==}
+    dependencies:
+      cookie: 0.5.0
+    dev: true
+
+  /@bundled-es-modules/statuses@1.0.1:
+    resolution: {integrity: sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==}
+    dependencies:
+      statuses: 2.0.1
+    dev: true
 
   /@chainsafe/as-sha256@0.3.1:
     resolution: {integrity: sha512-hldFFYuf49ed7DAakWVXSJODuq3pzJEguD8tQ7h+sGkM18vja+OFoJI9krnGmgzyuZC2ETX0NOIcCTy31v2Mtg==}
@@ -4828,6 +4843,23 @@ packages:
       '@motionone/dom': 10.17.0
       tslib: 2.6.2
 
+  /@mswjs/cookies@1.1.0:
+    resolution: {integrity: sha512-0ZcCVQxifZmhwNBoQIrystCb+2sWBY2Zw8lpfJBPCHGCA/HWqehITeCRVIv4VMy8MPlaHo2w2pTHFV2pFfqKPw==}
+    engines: {node: '>=18'}
+    dev: true
+
+  /@mswjs/interceptors@0.25.15:
+    resolution: {integrity: sha512-s4jdyxmq1eeftfDXJ7MUiK/jlvYaU8Sr75+42hHCVBrYez0k51RHbMitKIKdmsF92Q6gwhp8Sm1MmvdA9llpcg==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/logger': 0.3.0
+      '@open-draft/until': 2.1.0
+      is-node-process: 1.2.0
+      outvariant: 1.4.2
+      strict-event-emitter: 0.5.1
+    dev: true
+
   /@mui/base@5.0.0-beta.24(@types/react@18.2.48)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-bKt2pUADHGQtqWDZ8nvL2Lvg2GNJyd/ZUgZAJoYzRgmnxBL9j36MSlS3+exEdYkikcnvVafcBtD904RypFKb0w==}
     engines: {node: '>=12.0.0'}
@@ -5806,6 +5838,21 @@ packages:
       '@octokit/webhooks-methods': 4.0.0
       '@octokit/webhooks-types': 7.1.0
       aggregate-error: 3.1.0
+
+  /@open-draft/deferred-promise@2.2.0:
+    resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+    dev: true
+
+  /@open-draft/logger@0.3.0:
+    resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
+    dependencies:
+      is-node-process: 1.2.0
+      outvariant: 1.4.2
+    dev: true
+
+  /@open-draft/until@2.1.0:
+    resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
+    dev: true
 
   /@openzeppelin/contracts@3.4.1-solc-0.7-2:
     resolution: {integrity: sha512-tAG9LWg8+M2CMu7hIsqHPaTyG4uDzjr6mhvH96LvOpLZZj6tgzTluBt+LsCf1/QaYrlis6pITvpIaIhE+iZB+Q==}
@@ -8437,6 +8484,10 @@ packages:
     resolution: {integrity: sha512-GsALrTL69mlwbAw/MHF1IPTadSLZQnsxe7a80G8l4inN/iEXCOcVeT/S7aRc6hbhqzL9qZ314kHPDQnQ3ev+HA==}
     dev: false
 
+  /@types/cookie@0.6.0:
+    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
+    dev: true
+
   /@types/debug@4.1.12:
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
     dependencies:
@@ -8702,6 +8753,10 @@ packages:
 
   /@types/stack-utils@2.0.3:
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+
+  /@types/statuses@2.0.4:
+    resolution: {integrity: sha512-eqNDvZsCNY49OAXB0Firg/Sc2BgoWsntsLUdybGFOhAfCD6QJ2n9HXUIHGqt5qjrxmMv4wS8WLAw43ZkKcJ8Pw==}
+    dev: true
 
   /@types/stylis@4.2.0:
     resolution: {integrity: sha512-n4sx2bqL0mW1tvDf/loQ+aMX7GQD3lc3fkCMC55VFNDu/vBOabO+LTIeXKM14xK0ppk5TUGcWRjiSpIlUpghKw==}
@@ -9327,6 +9382,7 @@ packages:
       '@vitest/spy': 1.1.3
       '@vitest/utils': 1.1.3
       chai: 4.4.0
+    dev: false
 
   /@vitest/expect@1.2.2:
     resolution: {integrity: sha512-3jpcdPAD7LwHUUiT2pZTj2U82I2Tcgg2oVPvKxhn6mDI2On6tfvPQTjAI4628GUGDZrCm4Zna9iQHm5cEexOAg==}
@@ -9341,6 +9397,7 @@ packages:
       '@vitest/utils': 1.1.3
       p-limit: 5.0.0
       pathe: 1.1.2
+    dev: false
 
   /@vitest/runner@1.2.2:
     resolution: {integrity: sha512-JctG7QZ4LSDXr5CsUweFgcpEvrcxOV1Gft7uHrvkQ+fsAVylmWQvnaAr/HDp3LAH1fztGMQZugIheTWjaGzYIg==}
@@ -9355,6 +9412,7 @@ packages:
       magic-string: 0.30.5
       pathe: 1.1.2
       pretty-format: 29.7.0
+    dev: false
 
   /@vitest/snapshot@1.2.2:
     resolution: {integrity: sha512-SmGY4saEw1+bwE1th6S/cZmPxz/Q4JWsl7LvbQIky2tKE35US4gd0Mjzqfr84/4OD0tikGWaWdMja/nWL5NIPA==}
@@ -9367,6 +9425,7 @@ packages:
     resolution: {integrity: sha512-Ec0qWyGS5LhATFQtldvChPTAHv08yHIOZfiNcjwRQbFPHpkih0md9KAbs7TfeIfL7OFKoe7B/6ukBTqByubXkQ==}
     dependencies:
       tinyspy: 2.2.0
+    dev: false
 
   /@vitest/spy@1.2.2:
     resolution: {integrity: sha512-k9Gcahssw8d7X3pSLq3e3XEu/0L78mUkCjivUqCQeXJm9clfXR/Td8+AP+VC1O6fKPIDLcHDTAmBOINVuv6+7g==}
@@ -9380,6 +9439,7 @@ packages:
       estree-walker: 3.0.3
       loupe: 2.3.7
       pretty-format: 29.7.0
+    dev: false
 
   /@vitest/utils@1.2.2:
     resolution: {integrity: sha512-WKITBHLsBHlpjnDQahr+XK6RE7MiAsgrIkr0pGhQ9ygoxBfUeG0lUG5iLlzqjmKSlBv3+j5EGsriBzh+C3Tq9g==}
@@ -10049,6 +10109,7 @@ packages:
   /acorn-walk@8.3.1:
     resolution: {integrity: sha512-TgUZgYvqZprrl7YldZNoa9OciCAyZR+Ejm9eXzKCmjsF5IKp/wgQ7Z/ZpjpGTIUPwrHQIcYeI8qDh4PsEwxMbw==}
     engines: {node: '>=0.4.0'}
+    dev: false
 
   /acorn-walk@8.3.2:
     resolution: {integrity: sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==}
@@ -10150,7 +10211,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       type-fest: 0.21.3
-    dev: false
 
   /ansi-fragments@0.2.1:
     resolution: {integrity: sha512-DykbNHxuXQwUDRv5ibc2b0x7uw7wmwOGLBUd5RmaQ5z8Lhx19vwvKV+FAsM5rEA6dEcHxX+/Ad5s9eF2k2bB+w==}
@@ -10982,7 +11042,6 @@ packages:
 
   /chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
-    dev: false
 
   /check-error@1.0.3:
     resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
@@ -11107,7 +11166,6 @@ packages:
   /cli-width@3.0.0:
     resolution: {integrity: sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==}
     engines: {node: '>= 10'}
-    dev: false
 
   /cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
@@ -11341,6 +11399,11 @@ packages:
     resolution: {integrity: sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==}
     engines: {node: '>= 0.6'}
     dev: false
+
+  /cookie@0.5.0:
+    resolution: {integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==}
+    engines: {node: '>= 0.6'}
+    dev: true
 
   /cookies@0.8.0:
     resolution: {integrity: sha512-8aPsApQfebXnuI+537McwYsDtjVxGm8gTIzQI3FDW6t5t/DAhERxtnbEPN/8RX+uZthoz4eCOgloXaE5cYyNow==}
@@ -13108,7 +13171,6 @@ packages:
       chardet: 0.7.0
       iconv-lite: 0.4.24
       tmp: 0.0.33
-    dev: false
 
   /extract-files@9.0.0:
     resolution: {integrity: sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ==}
@@ -13201,7 +13263,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       escape-string-regexp: 1.0.5
-    dev: false
 
   /figures@5.0.0:
     resolution: {integrity: sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==}
@@ -13836,6 +13897,11 @@ packages:
     engines: {node: '>= 10.x'}
     dev: false
 
+  /graphql@16.8.1:
+    resolution: {integrity: sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+    dev: true
+
   /gtoken@7.0.1:
     resolution: {integrity: sha512-KcFVtoP1CVFtQu0aSk3AyAt2og66PFhZAlkUOuWKwzMLoulHXG5W5wE5xAnHb+yl3/wEFoqGW7/cDGMU8igDZQ==}
     engines: {node: '>=14.0.0'}
@@ -14045,6 +14111,10 @@ packages:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
     dev: false
+
+  /headers-polyfill@4.0.2:
+    resolution: {integrity: sha512-EWGTfnTqAO2L/j5HZgoM/3z82L7necsJ0pO9Tp0X1wil3PDLrkypTBRgVO2ExehEEvUycejZD3FuRaXpZZc3kw==}
+    dev: true
 
   /help-me@4.2.0:
     resolution: {integrity: sha512-TAOnTB8Tz5Dw8penUuzHVrKNKlCIbwwbHnXraNJxPwf8LRtE2HlM84RYuezMFcwOJmoYOCWVDyJ8TQGxn9PgxA==}
@@ -14259,7 +14329,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       safer-buffer: 2.1.2
-    dev: false
 
   /iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -14374,7 +14443,6 @@ packages:
       strip-ansi: 6.0.1
       through: 2.3.8
       wrap-ansi: 6.2.0
-    dev: false
 
   /inquirer@9.2.12:
     resolution: {integrity: sha512-mg3Fh9g2zfuVWJn6lhST0O7x4n03k7G8Tx5nvikJkbq8/CK47WDVm+UznF0G6s5Zi0KcyUisr6DU8T67N5U+1Q==}
@@ -14620,6 +14688,10 @@ packages:
   /is-negative-zero@2.0.2:
     resolution: {integrity: sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==}
     engines: {node: '>= 0.4'}
+
+  /is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
+    dev: true
 
   /is-number-object@1.0.7:
     resolution: {integrity: sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==}
@@ -16777,6 +16849,38 @@ packages:
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  /msw@2.1.5(typescript@5.3.3):
+    resolution: {integrity: sha512-r39AZk4taMmUEYwtzDAgFy38feqJy1yaKykvo0QE8q7H7c28yH/WIlOmE7oatjkC3dMgpTYfND8MaxeywgU+Yg==}
+    engines: {node: '>=18'}
+    hasBin: true
+    requiresBuild: true
+    peerDependencies:
+      typescript: '>= 4.7.x <= 5.3.x'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@bundled-es-modules/cookie': 2.0.0
+      '@bundled-es-modules/statuses': 1.0.1
+      '@mswjs/cookies': 1.1.0
+      '@mswjs/interceptors': 0.25.15
+      '@open-draft/until': 2.1.0
+      '@types/cookie': 0.6.0
+      '@types/statuses': 2.0.4
+      chalk: 4.1.2
+      chokidar: 3.5.3
+      graphql: 16.8.1
+      headers-polyfill: 4.0.2
+      inquirer: 8.2.6
+      is-node-process: 1.2.0
+      outvariant: 1.4.2
+      path-to-regexp: 6.2.1
+      strict-event-emitter: 0.5.1
+      type-fest: 4.10.1
+      typescript: 5.3.3
+      yargs: 17.7.2
+    dev: true
+
   /multibase@4.0.6:
     resolution: {integrity: sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==}
     engines: {node: '>=12.0.0', npm: '>=6.0.0'}
@@ -16807,7 +16911,6 @@ packages:
 
   /mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
-    dev: false
 
   /mute-stream@1.0.0:
     resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
@@ -17429,10 +17532,13 @@ packages:
   /os-tmpdir@1.0.2:
     resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
     engines: {node: '>=0.10.0'}
-    dev: false
 
   /outdent@0.8.0:
     resolution: {integrity: sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A==}
+    dev: true
+
+  /outvariant@1.4.2:
+    resolution: {integrity: sha512-Ou3dJ6bA/UJ5GVHxah4LnqDwZRwAmWxrG3wtrHrbGnP4RnLCtA64A4F+ae7Y8ww660JaddSoArUR5HjipWSHAQ==}
     dev: true
 
   /p-cancelable@0.4.1:
@@ -17678,6 +17784,10 @@ packages:
     engines: {node: '>=8.15'}
     dependencies:
       unique-string: 2.0.0
+    dev: true
+
+  /path-to-regexp@6.2.1:
+    resolution: {integrity: sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==}
     dev: true
 
   /path-type@4.0.0:
@@ -19186,7 +19296,6 @@ packages:
   /run-async@2.4.1:
     resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
     engines: {node: '>=0.12.0'}
-    dev: false
 
   /run-async@3.0.0:
     resolution: {integrity: sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==}
@@ -19804,6 +19913,10 @@ packages:
       fast-fifo: 1.3.2
       queue-tick: 1.0.1
 
+  /strict-event-emitter@0.5.1:
+    resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
+    dev: true
+
   /strict-uri-encode@1.1.0:
     resolution: {integrity: sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ==}
     engines: {node: '>=0.10.0'}
@@ -20330,7 +20443,6 @@ packages:
 
   /through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
-    dev: false
 
   /timed-out@4.0.1:
     resolution: {integrity: sha512-G7r3AhovYtr5YKOWQkta8RKAPb+J9IsO4uVmzjl8AZwfhs8UcUwTiD6gcJYSgOtzyjvQKrKYn41syHbUWMkafA==}
@@ -20378,6 +20490,7 @@ packages:
   /tinypool@0.8.1:
     resolution: {integrity: sha512-zBTCK0cCgRROxvs9c0CGK838sPkeokNGdQVUUwHAbynHFlmyJYj825f/oRs528HaIJ97lo0pLIlDUzwN+IorWg==}
     engines: {node: '>=14.0.0'}
+    dev: false
 
   /tinypool@0.8.2:
     resolution: {integrity: sha512-SUszKYe5wgsxnNOVlBYO6IC+8VGWdVGZWAqUxp3UErNBtptZvWbwyUOyzNL59zigz2rCA92QiL3wvG+JDSdJdQ==}
@@ -20398,7 +20511,6 @@ packages:
     engines: {node: '>=0.6.0'}
     dependencies:
       os-tmpdir: 1.0.2
-    dev: false
 
   /tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
@@ -20650,7 +20762,6 @@ packages:
   /type-fest@0.21.3:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
-    dev: false
 
   /type-fest@0.6.0:
     resolution: {integrity: sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==}
@@ -20660,6 +20771,11 @@ packages:
   /type-fest@0.7.1:
     resolution: {integrity: sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==}
     engines: {node: '>=8'}
+
+  /type-fest@4.10.1:
+    resolution: {integrity: sha512-7ZnJYTp6uc04uYRISWtiX3DSKB/fxNQT0B5o1OUeCqiQiwF+JC9+rJiZIDrPrNCLLuTqyQmh4VdQqh/ZOkv9MQ==}
+    engines: {node: '>=16'}
+    dev: true
 
   /type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
@@ -21173,27 +21289,6 @@ packages:
       - utf-8-validate
       - zod
 
-  /vite-node@1.1.3(@types/node@18.11.14):
-    resolution: {integrity: sha512-BLSO72YAkIUuNrOx+8uznYICJfTEbvBAmWClY3hpath5+h1mbPS5OMn42lrTxXuyCazVyZoDkSRnju78GiVCqA==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    dependencies:
-      cac: 6.7.14
-      debug: 4.3.4(supports-color@5.5.0)
-      pathe: 1.1.2
-      picocolors: 1.0.0
-      vite: 5.0.12(@types/node@18.11.14)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-    dev: true
-
   /vite-node@1.1.3(@types/node@20.11.5):
     resolution: {integrity: sha512-BLSO72YAkIUuNrOx+8uznYICJfTEbvBAmWClY3hpath5+h1mbPS5OMn42lrTxXuyCazVyZoDkSRnju78GiVCqA==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -21214,6 +21309,27 @@ packages:
       - supports-color
       - terser
     dev: false
+
+  /vite-node@1.2.2(@types/node@18.11.14):
+    resolution: {integrity: sha512-1as4rDTgVWJO3n1uHmUYqq7nsFgINQ9u+mRcXpjeOMJUmviqNKjcZB7UfRZrlM7MjYXMKpuWp5oGkjaFLnjawg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.4(supports-color@5.5.0)
+      pathe: 1.1.2
+      picocolors: 1.0.0
+      vite: 5.0.12(@types/node@18.11.14)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
 
   /vite-node@1.2.2(@types/node@20.11.5):
     resolution: {integrity: sha512-1as4rDTgVWJO3n1uHmUYqq7nsFgINQ9u+mRcXpjeOMJUmviqNKjcZB7UfRZrlM7MjYXMKpuWp5oGkjaFLnjawg==}
@@ -21306,71 +21422,13 @@ packages:
     optionalDependencies:
       fsevents: 2.3.3
 
-  /vitest-canvas-mock@0.3.3(vitest@1.1.3):
+  /vitest-canvas-mock@0.3.3(vitest@1.2.2):
     resolution: {integrity: sha512-3P968tYBpqYyzzOaVtqnmYjqbe13576/fkjbDEJSfQAkHtC5/UjuRHOhFEN/ZV5HVZIkaROBUWgazDKJ+Ibw+Q==}
     peerDependencies:
       vitest: '*'
     dependencies:
       jest-canvas-mock: 2.5.2
-      vitest: 1.1.3(@types/node@18.11.14)(jsdom@23.2.0)
-    dev: true
-
-  /vitest@1.1.3(@types/node@18.11.14)(jsdom@23.2.0):
-    resolution: {integrity: sha512-2l8om1NOkiA90/Y207PsEvJLYygddsOyr81wLQ20Ra8IlLKbyQncWsGZjnbkyG2KwwuTXLQjEPOJuxGMG8qJBQ==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': ^1.0.0
-      '@vitest/ui': ^1.0.0
-      happy-dom: '*'
-      jsdom: '*'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@types/node':
-        optional: true
-      '@vitest/browser':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
-        optional: true
-    dependencies:
-      '@types/node': 18.11.14
-      '@vitest/expect': 1.1.3
-      '@vitest/runner': 1.1.3
-      '@vitest/snapshot': 1.1.3
-      '@vitest/spy': 1.1.3
-      '@vitest/utils': 1.1.3
-      acorn-walk: 8.3.1
-      cac: 6.7.14
-      chai: 4.4.0
-      debug: 4.3.4(supports-color@5.5.0)
-      execa: 8.0.1
-      jsdom: 23.2.0
-      local-pkg: 0.5.0
-      magic-string: 0.30.5
-      pathe: 1.1.2
-      picocolors: 1.0.0
-      std-env: 3.7.0
-      strip-literal: 1.3.0
-      tinybench: 2.5.1
-      tinypool: 0.8.1
-      vite: 5.0.12(@types/node@18.11.14)
-      vite-node: 1.1.3(@types/node@18.11.14)
-      why-is-node-running: 2.2.2
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
+      vitest: 1.2.2(@types/node@18.11.14)(jsdom@23.2.0)
     dev: true
 
   /vitest@1.1.3(@types/node@20.11.5)(jsdom@23.2.0):
@@ -21430,6 +21488,64 @@ packages:
       - supports-color
       - terser
     dev: false
+
+  /vitest@1.2.2(@types/node@18.11.14)(jsdom@23.2.0):
+    resolution: {integrity: sha512-d5Ouvrnms3GD9USIK36KG8OZ5bEvKEkITFtnGv56HFaSlbItJuYr7hv2Lkn903+AvRAgSixiamozUVfORUekjw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': ^1.0.0
+      '@vitest/ui': ^1.0.0
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@types/node': 18.11.14
+      '@vitest/expect': 1.2.2
+      '@vitest/runner': 1.2.2
+      '@vitest/snapshot': 1.2.2
+      '@vitest/spy': 1.2.2
+      '@vitest/utils': 1.2.2
+      acorn-walk: 8.3.2
+      cac: 6.7.14
+      chai: 4.4.0
+      debug: 4.3.4(supports-color@5.5.0)
+      execa: 8.0.1
+      jsdom: 23.2.0
+      local-pkg: 0.5.0
+      magic-string: 0.30.5
+      pathe: 1.1.2
+      picocolors: 1.0.0
+      std-env: 3.7.0
+      strip-literal: 1.3.0
+      tinybench: 2.5.1
+      tinypool: 0.8.2
+      vite: 5.0.12(@types/node@18.11.14)
+      vite-node: 1.2.2(@types/node@18.11.14)
+      why-is-node-running: 2.2.2
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
 
   /vitest@1.2.2(@types/node@20.11.5)(jsdom@23.2.0):
     resolution: {integrity: sha512-d5Ouvrnms3GD9USIK36KG8OZ5bEvKEkITFtnGv56HFaSlbItJuYr7hv2Lkn903+AvRAgSixiamozUVfORUekjw==}
@@ -22080,9 +22196,9 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: true
 
-  github.com/chainapsis/keplr-chain-registry/58f56188f5b0d05a2858a018a19b14c102d262b7(@babel/core@7.23.7)(react-is@18.2.0):
-    resolution: {tarball: https://codeload.github.com/chainapsis/keplr-chain-registry/tar.gz/58f56188f5b0d05a2858a018a19b14c102d262b7}
-    id: github.com/chainapsis/keplr-chain-registry/58f56188f5b0d05a2858a018a19b14c102d262b7
+  github.com/chainapsis/keplr-chain-registry/eb0c68c27346f03388f2797a151cae1e830cf2bb(@babel/core@7.23.7)(react-is@18.2.0):
+    resolution: {tarball: https://codeload.github.com/chainapsis/keplr-chain-registry/tar.gz/eb0c68c27346f03388f2797a151cae1e830cf2bb}
+    id: github.com/chainapsis/keplr-chain-registry/eb0c68c27346f03388f2797a151cae1e830cf2bb
     name: chainapsis-suggest-chain
     version: 0.0.1
     dependencies:


### PR DESCRIPTION
# 🧙 Description

- Use msw for mocking responses for integration tests (missing on staking)
- Reorganize mocks: you can find them on vitest config file.

Ticket #

## ✅ Checklist

- [ ] Acceptance Criteria described in the ticket are met
- [ ] Texts and strings are in the related i18n file
- [ ] Utilities have unit tests
- [ ] User stories and functionalities have integration or e2e tests
- [ ] If adding a new token or network
  - [ ] Registry package is updated
  - [ ] Asset images are added
- [ ] Related packages.json are upgraded
- [ ] Changelog is updated
