### PR TITLE
fix: vesting page translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+- (fix) fse-965 | packages/i18n 1.0.3 pages/vesting 1.0.1 | Fix vesting page translations
+
 ## 2.0.2 - 2024-01-29
 
 - (chore) packages/widgets 1.0.2 | Upgrade Foprge widget to 1.2.8

--- a/packages/i18n/locales/en/vesting.json
+++ b/packages/i18n/locales/en/vesting.json
@@ -40,6 +40,7 @@
   "vesting.executioner.address.title": "SAFE ADDRESS",
   "vesting.approve.button": "Approve",
   "vesting.executioner.address.body": "Your address is going to be the executioner for the fund transaction. This means that you will have to execute the transaction after all the other multisign owners have signed.",
+  "vesting.executioner.placeholder": "Enter safe address",
   "vesting.fund.account.name.title": "ACCOUNT NAME",
   "vesting.finish.fund.title": "Finish Funding Vesting Account",
   "vesting.finish.fund.button": "Execute",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evmosapps/i18n",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "type": "module",
   "devDependencies": {

--- a/pages/vesting/package.json
+++ b/pages/vesting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evmosapps/vesting-page",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "type": "module",
   "main": "./src/index.tsx",

--- a/pages/vesting/src/components/vesting/header/ApproveFunding.tsx
+++ b/pages/vesting/src/components/vesting/header/ApproveFunding.tsx
@@ -64,13 +64,13 @@ export default function ApproveFunding({ onClose }: { onClose: () => void }) {
       <div className="flex flex-col space-y-3">
         <span>{t("vesting.executioner.address.body")}</span>
         <label htmlFor="address" className="text-xs font-bold">
-          {t("vesting.safe.address.title")}
+          {t("vesting.executioner.address.title")}
         </label>
         <input
           id="address"
           onChange={(e) => setSafeAddress(e.target.value)}
           className="textBoxStyle"
-          placeholder="Enter safe address"
+          placeholder={t("vesting.executioner.placeholder")}
         />
         <button
           onClick={handleApprove}


### PR DESCRIPTION
# 🧙 Description

Fix translation for safe address
Move placeholder text to i18n file.

Ticket #fse-965

## ✅ Checklist

- [ ] Acceptance Criteria described in the ticket are met
- [ ] Texts and strings are in the related i18n file
- [ ] Utilities have unit tests
- [ ] User stories and functionalities have integration or e2e tests
- [ ] If adding a new token or network
  - [ ] Registry package is updated
  - [ ] Asset images are added
- [ ] Related packages.json are upgraded
- [ ] Changelog is updated
