### PR TITLE
fix: remove wevmos row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+- (fix) XAP-96 pages/portfolio 1.1.10 | single token representation: remove WEVMOS row
+
 - (fix) XAP-98 pages/portfolio 1.1.9 | single token representation: remove convert buttons
 
 - (fix) XAP-92 pages/portfolio 1.1.8 | single token representation: remove wrapping buttons

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evmos-apps",
-  "version": "2.0.4",
+  "version": "2.0.2",
   "license": "SEE LICENSE IN LICENSE",
   "author": "Tharsis Labs Ltd.(Evmos)",
   "private": true,

--- a/pages/portfolio/package.json
+++ b/pages/portfolio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evmosapps/portfolio-page",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "private": true,
   "type": "module",
   "main": "./src/index.tsx",

--- a/pages/portfolio/src/asset/table/ContentTable.tsx
+++ b/pages/portfolio/src/asset/table/ContentTable.tsx
@@ -5,7 +5,6 @@ import { BigNumber } from "@ethersproject/bignumber";
 import { Dispatch, SetStateAction, useMemo } from "react";
 
 import { addAssets, addDollarAssets, formatNumber } from "helpers";
-import { EVMOS_SYMBOL } from "@evmosapps/evmos-wallet";
 import { Accordion } from "@evmosapps/ui-helpers";
 import { RowContent } from "./components/RowContent";
 import { SubRowContent } from "./components/SubRowContent";
@@ -25,24 +24,14 @@ const createSubRow = (
   setIsOpen: Dispatch<SetStateAction<boolean>>,
   setModalContent: Dispatch<SetStateAction<JSX.Element>>,
   feeBalance: BigNumber,
-  isIBCBalance: boolean,
 ) => {
-  // Filter to prevent rendering of Wevmos
-  if (!isIBCBalance && item.symbol === EVMOS_SYMBOL) {
-    return null;
-  }
-
   return (
-    <div
-      className="subrow w-full"
-      key={isIBCBalance ? item.symbol.toLocaleLowerCase() : item.symbol}
-    >
+    <div className="subrow w-full" key={item.symbol}>
       <SubRowContent
         item={item}
         setIsOpen={setIsOpen}
         setModalContent={setModalContent}
         feeBalance={feeBalance}
-        isIBCBalance={isIBCBalance}
       />
     </div>
   );
@@ -111,33 +100,9 @@ const ContentTable = ({
 
       content = [];
       v.tokens.forEach((e) => {
-        const subRowContent =
-          e.symbol === EVMOS_SYMBOL
-            ? [
-                createSubRow(
-                  e,
-                  setIsOpen,
-                  setModalContent,
-                  tableData.feeBalance,
-                  false,
-                ),
-                createSubRow(
-                  e,
-                  setIsOpen,
-                  setModalContent,
-                  tableData.feeBalance,
-                  true,
-                ),
-              ]
-            : [
-                createSubRow(
-                  e,
-                  setIsOpen,
-                  setModalContent,
-                  tableData.feeBalance,
-                  false,
-                ),
-              ];
+        const subRowContent = [
+          createSubRow(e, setIsOpen, setModalContent, tableData.feeBalance),
+        ];
         // Ensure that content and subRowContent do not include 'null' elements in the final result
         if (content) {
           content = [

--- a/pages/portfolio/src/asset/table/ContentTable.tsx
+++ b/pages/portfolio/src/asset/table/ContentTable.tsx
@@ -27,6 +27,11 @@ const createSubRow = (
   feeBalance: BigNumber,
   isIBCBalance: boolean,
 ) => {
+  // Filter to prevent rendering of Wevmos
+  if (!isIBCBalance && item.symbol === EVMOS_SYMBOL) {
+    return null;
+  }
+
   return (
     <div
       className="subrow w-full"
@@ -105,42 +110,48 @@ const ContentTable = ({
       let valueInTokens = 0;
 
       content = [];
-      v.tokens.map((e) => {
-        if (e.symbol === EVMOS_SYMBOL) {
-          content?.unshift(
-            createSubRow(
-              e,
-              setIsOpen,
-              setModalContent,
-              tableData.feeBalance,
-              false,
-            ),
-          );
-          content?.unshift(
-            createSubRow(
-              e,
-              setIsOpen,
-              setModalContent,
-              tableData.feeBalance,
-              true,
-            ),
-          );
-        } else {
-          content?.push(
-            createSubRow(
-              e,
-              setIsOpen,
-              setModalContent,
-              tableData.feeBalance,
-              false,
-            ),
-          );
+      v.tokens.forEach((e) => {
+        const subRowContent =
+          e.symbol === EVMOS_SYMBOL
+            ? [
+                createSubRow(
+                  e,
+                  setIsOpen,
+                  setModalContent,
+                  tableData.feeBalance,
+                  false,
+                ),
+                createSubRow(
+                  e,
+                  setIsOpen,
+                  setModalContent,
+                  tableData.feeBalance,
+                  true,
+                ),
+              ]
+            : [
+                createSubRow(
+                  e,
+                  setIsOpen,
+                  setModalContent,
+                  tableData.feeBalance,
+                  false,
+                ),
+              ];
+        // Ensure that content and subRowContent do not include 'null' elements in the final result
+        if (content) {
+          content = [
+            ...content,
+            ...subRowContent.filter((el) => el !== null),
+          ] as JSX.Element[];
         }
+
         valueInTokens += addAssets({
           erc20Balance: e.erc20Balance,
           decimals: e.decimals,
           cosmosBalance: e.cosmosBalance,
         });
+
         valueInDollars += addDollarAssets({
           erc20Balance: e.erc20Balance,
           decimals: e.decimals,

--- a/pages/portfolio/src/asset/table/ContentTable.tsx
+++ b/pages/portfolio/src/asset/table/ContentTable.tsx
@@ -99,17 +99,10 @@ const ContentTable = ({
       let valueInTokens = 0;
 
       content = [];
-      v.tokens.forEach((e) => {
-        const subRowContent = [
+      v.tokens.map((e) => {
+        content?.push(
           createSubRow(e, setIsOpen, setModalContent, tableData.feeBalance),
-        ];
-        // Ensure that content and subRowContent do not include 'null' elements in the final result
-        if (content) {
-          content = [
-            ...content,
-            ...subRowContent.filter((el) => el !== null),
-          ] as JSX.Element[];
-        }
+        );
 
         valueInTokens += addAssets({
           erc20Balance: e.erc20Balance,

--- a/pages/portfolio/src/asset/table/components/SubRowContent.tsx
+++ b/pages/portfolio/src/asset/table/components/SubRowContent.tsx
@@ -12,18 +12,12 @@ import { SubRowProps } from "./types";
 import { useCallback } from "react";
 export const SubRowContent = ({ item, isIBCBalance = false }: SubRowProps) => {
   let balance = item.erc20Balance;
-  let symbol = item.symbol;
-  let description = item.description;
-  let img = item.pngSrc;
+  const symbol = item.symbol;
+  const description = item.description;
+  const img = item.pngSrc;
 
   if (isIBCBalance) {
     balance = item.cosmosBalance;
-  } else {
-    if (item.symbol === EVMOS_SYMBOL) {
-      symbol = "WEVMOS";
-      description = "Wrapped EVMOS";
-      img = "/tokens/wevmos.png";
-    }
   }
 
   const createV10Tooltip = () => {

--- a/pages/portfolio/src/asset/table/components/SubRowContent.tsx
+++ b/pages/portfolio/src/asset/table/components/SubRowContent.tsx
@@ -10,15 +10,12 @@ import { QuestionMarkIcon } from "@evmosapps/icons/QuestionMarkIcon";
 import { Description } from "./Description";
 import { SubRowProps } from "./types";
 import { useCallback } from "react";
-export const SubRowContent = ({ item, isIBCBalance = false }: SubRowProps) => {
-  let balance = item.erc20Balance;
+
+export const SubRowContent = ({ item }: SubRowProps) => {
+  const balance = item.erc20Balance;
   const symbol = item.symbol;
   const description = item.description;
   const img = item.pngSrc;
-
-  if (isIBCBalance) {
-    balance = item.cosmosBalance;
-  }
 
   const createV10Tooltip = () => {
     return (

--- a/pages/portfolio/src/asset/table/components/subrow-content.spec.tsx
+++ b/pages/portfolio/src/asset/table/components/subrow-content.spec.tsx
@@ -44,7 +44,6 @@ describe("Testing Tab Nav Item ", () => {
         setIsOpen={vi.fn()}
         setModalContent={vi.fn()}
         feeBalance={BigNumber.from(1)}
-        isIBCBalance={true}
       />,
       { wrapper },
     );
@@ -65,7 +64,6 @@ describe("Testing Tab Nav Item ", () => {
         setIsOpen={vi.fn()}
         setModalContent={vi.fn()}
         feeBalance={BigNumber.from(1)}
-        isIBCBalance={true}
       />,
       { wrapper },
     );

--- a/pages/portfolio/src/asset/table/components/types.ts
+++ b/pages/portfolio/src/asset/table/components/types.ts
@@ -9,7 +9,6 @@ export type SubRowProps = {
   item: TableDataElement;
   setIsOpen: Dispatch<SetStateAction<boolean>>;
   setModalContent: Dispatch<SetStateAction<JSX.Element>>;
-  isIBCBalance?: boolean;
   feeBalance: BigNumber;
 };
 


### PR DESCRIPTION
Delete the WEVMOS row from the balance table and continue with the modifications to implement single token representation.

- A filter was created that when listing the balance, filters the EVMOS erc20 values ​​so as not to save them in the array shown on the screen.

- Modifications were made to the table to avoid conflicts with the variables.

- The values ​​associated with WEVMOS were removed from the subrow.

⚠️ The website was adapted to receive the new balances, so until the modifications are made in the backend, some balances may not give correct values.
