### PR TITLE
fix: remove double balance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+- (fix) XAP-96 pages/portfolio 1.1.11 | single token representation: remove double balance
+
 - (fix) XAP-96 pages/portfolio 1.1.10 | single token representation: remove WEVMOS row
 
 - (fix) XAP-98 pages/portfolio 1.1.9 | single token representation: remove convert buttons

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
-- (fix) XAP-96 pages/portfolio 1.1.11 | single token representation: remove double balance
+- (fix) XAP-106 pages/portfolio 1.1.11 | single token representation: remove double balance
 
 - (fix) XAP-96 pages/portfolio 1.1.10 | single token representation: remove WEVMOS row
 

--- a/pages/portfolio/package.json
+++ b/pages/portfolio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evmosapps/portfolio-page",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "private": true,
   "type": "module",
   "main": "./src/index.tsx",

--- a/pages/portfolio/src/asset/table/components/SubRowContent.tsx
+++ b/pages/portfolio/src/asset/table/components/SubRowContent.tsx
@@ -1,10 +1,7 @@
 // Copyright Tharsis Labs Ltd.(Evmos)
 // SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
 
-import { BigNumber } from "@ethersproject/bignumber";
-import Link from "next/link";
 import { amountToDollars, convertAndFormat } from "helpers";
-import { EVMOS_SYMBOL } from "@evmosapps/evmos-wallet";
 import { Tooltip } from "@evmosapps/ui-helpers";
 import { QuestionMarkIcon } from "@evmosapps/icons/QuestionMarkIcon";
 import { Description } from "./Description";
@@ -16,41 +13,6 @@ export const SubRowContent = ({ item }: SubRowProps) => {
   const symbol = item.symbol;
   const description = item.description;
   const img = item.pngSrc;
-
-  const createV10Tooltip = () => {
-    return (
-      <div
-        className={`text-xs capitalize ${
-          item.cosmosBalance.eq(BigNumber.from("0")) ||
-          item.symbol === EVMOS_SYMBOL
-            ? "hidden"
-            : ""
-        }`}
-      >
-        <Tooltip
-          className="w-24"
-          element={<QuestionMarkIcon width={16} height={16} />}
-          text={
-            <>
-              Since{" "}
-              <Link
-                className="text-red-300"
-                href={v10Link}
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                v10
-              </Link>{" "}
-              upgrade, all withdraws will pull first from IBC token balance
-              before ERC-20. Deposits are autoconverted to ERC-20
-            </>
-          }
-        />
-      </div>
-    );
-  };
-  const v10Link =
-    "https://commonwealth.im/evmos/discussion/8501-evmos-software-upgrade-v10";
 
   const createCoingeckoAlert = useCallback(() => {
     return (
@@ -95,27 +57,6 @@ export const SubRowContent = ({ item }: SubRowProps) => {
           <span className="break-all text-base font-bold">
             {convertAndFormat(balance, item.decimals, 6)}
           </span>
-          {/* displays ibc balance */}
-          <div
-            className={` ${
-              item.cosmosBalance.eq(BigNumber.from("0")) ||
-              item.symbol === EVMOS_SYMBOL
-                ? "hidden"
-                : ""
-            } flex items-center justify-end font-bold lg:justify-start`}
-          >
-            <div className="block pr-1 lg:hidden">{createV10Tooltip()}</div>
-            <Tooltip
-              className="capitalize"
-              element={
-                <p className="break-all text-sm opacity-80">
-                  {convertAndFormat(item.cosmosBalance, item.decimals)}{" "}
-                </p>
-              }
-              text="IBC Balance"
-            />
-            <div className="hidden pl-1 lg:block">{createV10Tooltip()}</div>
-          </div>
 
           {/* displays erc20 tokens in dollars */}
           {/* stevmos uses evmos price until they add it on coingecko. 


### PR DESCRIPTION
# 🧙 Description

Subbalances that appear on the sublines of each token have been removed.

ISC20 balances were removed instead of ERC20 as indicated in the task, as the core team was consulted and it was recommended to make this change.

While all references to balances of type cosmos could be removed, the overall balance in the [ContentTable.tsx](https://github.com/evmos/apps/blob/main/pages/portfolio/src/asset/table/ContentTable.tsx) component was not modified so as not to interfere with other tickets.

Ticket #

## ✅ Checklist

- [ ] Acceptance Criteria described in the ticket are met
- [ ] Texts and strings are in the related i18n file
- [ ] Utilities have unit tests
- [ ] User stories and functionalities have integration or e2e tests
- [ ] If adding a new token or network
  - [ ] Registry package is updated
  - [ ] Asset images are added
- [ ] Related packages.json are upgraded
- [ ] Changelog is updated
