### PR TITLE
limit of highlighted dapps to 8 not 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+- (fix) dapp-58 | pages/dappstore | Update ecosystem section - show 8 dapps
+
 ## 2.0.12 - 2024-03-18
 
 - (fix) xap-151 | packages/widgets 1.0.8 packages/instant-dapps 1.0.5 pages/dapp-store 1.1.8 | Add Leap Elements instant dapp

--- a/pages/dappstore/package.json
+++ b/pages/dappstore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evmosapps/dappstore-page",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "private": true,
   "type": "module",
   "main": "./src/index.tsx",

--- a/pages/dappstore/src/pages/landing/partials/ecosystem-section.tsx
+++ b/pages/dappstore/src/pages/landing/partials/ecosystem-section.tsx
@@ -11,28 +11,19 @@ import { fetchExplorerData } from "../../../lib/fetch-explorer-data";
 import { EcosystemCardGrid } from "./ecosystem-card-grid";
 import { CLICK_SEE_MORE_BUTTON } from "tracker";
 
-const landingdAppsOrder = [
-  "stride",
-  "osmosis",
-  "forge",
-  "squid",
-  "layerswap",
-  "wormhole",
-  "transak",
-];
 export const EcosystemSection = async () => {
   const { t } = await translation("dappStore");
   const { dApps } = await fetchExplorerData();
 
+  // if we want that some specific dApps don't appear in the instant dApps section
+  const blacklist = ["transak"];
+
   const instantDapps = dApps
     // get the instant dapps
     .filter((dApp) => dApp.instantDapp)
-    // sort them by the order in the array
-    .sort((a, b) => {
-      return (
-        landingdAppsOrder.indexOf(a.slug) - landingdAppsOrder.indexOf(b.slug)
-      );
-    });
+    // remove items from the blacklist
+    .filter((dApp) => !blacklist.includes(dApp.slug))
+    .slice(0, 8);
 
   return (
     <section className="space-y-8">


### PR DESCRIPTION
# 🧙 Description

limit of highlighted dapps to 8 not 9

Ticket #dapp-58

## ✅ Checklist

- [ ] Acceptance Criteria described in the ticket are met
- [ ] Texts and strings are in the related i18n file
- [ ] Utilities have unit tests
- [ ] User stories and functionalities have integration or e2e tests
- [ ] If adding a new token or network
  - [ ] Registry package is updated
  - [ ] Asset images are added
- [ ] Related packages.json are upgraded
- [ ] Changelog is updated
