### PR TITLE
chore: update forge widget router URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+- (chore) packages/widgets 1.0.9 | Update forge router URL
+
 ## 2.0.14 - 2024-04-25
 
 - (feat) apps/mission 1.0.36 | Implements script to sync notion images with vercel blobs

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evmosapps/widgets",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "main": "./src/index.tsx",
   "types": "./src/index.tsx",
   "type": "module",

--- a/packages/widgets/src/forge.tsx
+++ b/packages/widgets/src/forge.tsx
@@ -12,7 +12,7 @@ const Forge = () => {
       <SwapWidget
         width={"100%"}
         defaultChainId={9001}
-        routerUrl={"https://forge-router.evmosdao.xyz/"}
+        routerUrl={"https://a2skdrejs8.execute-api.eu-north-1.amazonaws.com/prod/"}
       />
     </div>
   );


### PR DESCRIPTION
This PR simply updates the Forge widget router URL to the new deployment managed by the evmos infra team
