### PR TITLE
fix: display name should be the user address

### DIFF
--- a/apps/mission/src/components/header/edit/ModalEdit.tsx
+++ b/apps/mission/src/components/header/edit/ModalEdit.tsx
@@ -22,7 +22,7 @@ export const profileImages = [purple, orange];
 
 export const EditModal = () => {
   const { isOpen, setIsOpen, modalProps } = useEditModal();
-  const { setIsDropdownOpen } = useWallet();
+  const { setIsDropdownOpen, address } = useWallet();
 
   const { name, handleSetName, img, handleSetImg } =
     useProfileContext() as ProfileContext;
@@ -89,7 +89,7 @@ export const EditModal = () => {
                 }
                 fullWidth
                 placeholder={t("profile.modal.placeholder")}
-                value={name}
+                value={name === "" ? address : name}
                 onChange={handleOnChange}
               />
             </div>


### PR DESCRIPTION
# 🧙 Description

Display hex address if user didn't ser profile name

Ticket #dapp-77

## ✅ Checklist

- [ ] Acceptance Criteria described in the ticket are met
- [ ] Texts and strings are in the related i18n file
- [ ] Utilities have unit tests
- [ ] User stories and functionalities have integration or e2e tests
- [ ] If adding a new token or network
  - [ ] Registry package is updated
  - [ ] Asset images are added
- [ ] Related packages.json are upgraded
- [ ] Changelog is updated
