### PR TITLE
use thumbnail instead of cover for ecosystem card

### DIFF
--- a/pages/dappstore/src/pages/landing/partials/ecosystem-card.tsx
+++ b/pages/dappstore/src/pages/landing/partials/ecosystem-card.tsx
@@ -17,7 +17,7 @@ import { Icon } from "./Icon";
 import { IconLightning } from "@evmosapps/ui/icons/filled/images/lightning.tsx";
 
 export const EcosystemCard = ({ data }: { data: DApp }) => {
-  const img = data.cover;
+  const img = data.thumbnail;
 
   return (
     <TrackerEvent


### PR DESCRIPTION
# 🧙 Description

fix: use thumbnail instead of cover for ecosystem card

Ticket #dapp-115

## ✅ Checklist

- [ ] Acceptance Criteria described in the ticket are met
- [ ] Texts and strings are in the related i18n file
- [ ] Utilities have unit tests
- [ ] User stories and functionalities have integration or e2e tests
- [ ] If adding a new token or network
  - [ ] Registry package is updated
  - [ ] Asset images are added
- [ ] Related packages.json are upgraded
- [ ] Changelog is updated
