### PR TITLE
dapp-145 disable outposts

### DIFF
--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evmosapps/widgets",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "main": "./src/index.tsx",
   "types": "./src/index.tsx",
   "type": "module",

--- a/packages/widgets/src/Osmosis/Osmosis.tsx
+++ b/packages/widgets/src/Osmosis/Osmosis.tsx
@@ -19,7 +19,7 @@ import { parseUnits } from "viem";
 import { formatUnits } from "@evmosapps/evmos-wallet/src/registry-actions/utils";
 import { EXPLORER_URL } from "@evmosapps/constants";
 
-export default function Osmosis() {
+export function OsmosisWidget() {
   const { data } = useOsmosisData();
 
   const {
@@ -473,6 +473,20 @@ export default function Osmosis() {
               ? "Insufficient balance"
               : "Swap"}
         </button>
+      </div>
+    </div>
+  );
+}
+
+export default function Osmosis() {
+  return (
+          <div
+      className={`relative blur-image after:absolute after:top-0 after:left-0 after:right-0 after:bottom-0 after:z-10 after:bg-[rgba(0,0,0,.3)] z-[10] h-[450px] bg-center bg-no-repeat bg-cover ${"bg-[url(/ecosystem/blur/osmosis-blur.png)]"} flex flex-col justify-center`}
+    >
+      <div className="z-[9999] text-center flex flex-col items-center space-y-3 text-lg px-8">
+        <p className="font-light">
+        We are currently in maintenance mode with the Osmosis instant dapp. This will be addressed by the next upgrade of the Evmos chain
+        </p>
       </div>
     </div>
   );

--- a/packages/widgets/src/Stride/Stride.tsx
+++ b/packages/widgets/src/Stride/Stride.tsx
@@ -26,7 +26,7 @@ import Link from "next/link";
 import { EXPLORER_URL } from "@evmosapps/constants";
 import { useEvmosData } from "./query-evmos-values";
 
-const StrideWidget = () => {
+export const StrideWidget = () => {
   const { themeClass, setTheme } = useTheme();
 
   const { balance, evmosPrice } = useEvmosData();
@@ -271,7 +271,15 @@ const StrideWidget = () => {
 export default function Stride() {
   return (
     <ThemeProvider>
-      <StrideWidget />
+          <div
+      className={`relative blur-image after:absolute after:top-0 after:left-0 after:right-0 after:bottom-0 after:z-10 after:bg-[rgba(0,0,0,.3)] z-[10] h-[450px] bg-center bg-no-repeat bg-cover ${"bg-[url(/ecosystem/blur/stride-blur.png)]"} flex flex-col justify-center`}
+    >
+      <div className="z-[9999] text-center flex flex-col items-center space-y-3 text-lg px-8">
+        <p className="font-light text-black">
+        We are currently in maintenance mode with the Stride instant dapp. This will be addressed by the next upgrade of the Evmos chain
+        </p>
+      </div>
+    </div>
     </ThemeProvider>
   );
 }


### PR DESCRIPTION
# 🧙 Description

Disables Stride and Osmosis outposts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added maintenance mode messages for both the Osmosis and Stride widgets.

- **Updates**
  - Updated widget versions to ensure compatibility and new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->