### PR TITLE
feat: add logic for mismatch addresses

### DIFF
--- a/apps/mission/src/components/header/signin/ManageProfileModal.tsx
+++ b/apps/mission/src/components/header/signin/ManageProfileModal.tsx
@@ -18,7 +18,7 @@ import { Button } from "@evmosapps/ui/button/index.tsx";
 import { useAccount } from "wagmi";
 import { useState } from "react";
 import { Spinner } from "@evmosapps/ui/components/spinners/Spinner.tsx";
-import { useUserProfile } from "@evmosapps/user/auth/use-user-session.ts";
+import { useUserSession } from "@evmosapps/user/auth/use-user-session.ts";
 import { signInWithEthereum } from "../../useSignInWithEthereum";
 import { useWallet } from "@evmosapps/evmos-wallet";
 
@@ -30,7 +30,7 @@ export const ManageProfileModal = () => {
   const { t } = useTranslation("dappStore");
   const { profile } = useProfileContext();
   const image = profileImages.find((image) => image.src === profile.img?.src);
-  const { data: user } = useUserProfile();
+  const { data: session } = useUserSession();
   // manage appearence of loader
   const [loading, setLoading] = useState(false);
   const queryClient = useQueryClient();
@@ -54,6 +54,8 @@ export const ManageProfileModal = () => {
       setLoading(false);
     },
   });
+
+  const profileAddress = session?.user?.walletAccount[0]?.address;
   return (
     <Modal
       isOpen={isOpen}
@@ -85,9 +87,7 @@ export const ManageProfileModal = () => {
               </div>
               <div>
                 <div className="text-base text-heading dark:text-heading-dark">
-                  <AddressDisplay
-                    address={user?.defaultWalletAccount.address}
-                  />
+                  <AddressDisplay address={profileAddress} />
                 </div>
                 <div className="text-base text-subheading dark:text-subheading-dark">
                   {t("manageProfile.options.profile.title")}
@@ -121,9 +121,7 @@ export const ManageProfileModal = () => {
               ) : (
                 <Button
                   size="sm"
-                  disabled={
-                    isPending || address === user?.defaultWalletAccount.address
-                  }
+                  disabled={isPending || address === profileAddress}
                   onClick={() => {
                     changeProfile();
                   }}

--- a/apps/mission/src/components/header/signin/ManageProfileModal.tsx
+++ b/apps/mission/src/components/header/signin/ManageProfileModal.tsx
@@ -6,7 +6,7 @@
 import { cn, useModal } from "helpers";
 
 import { Modal } from "@evmosapps/ui/components/dialog/Dialog.tsx";
-
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "@evmosapps/i18n/client";
 import { useProfileContext } from "../edit/useEdit";
 import { profileImages } from "../edit/ModalEdit";
@@ -18,10 +18,11 @@ import { Button } from "@evmosapps/ui/button/index.tsx";
 import { useAccount } from "wagmi";
 import { useState } from "react";
 import { Spinner } from "@evmosapps/ui/components/spinners/Spinner.tsx";
+import { useUserProfile } from "@evmosapps/user/auth/use-user-session.ts";
+import { signInWithEthereum } from "../../useSignInWithEthereum";
+import { useWallet } from "@evmosapps/evmos-wallet";
 
 export const useManageProfileModal = () => useModal("manage-profile");
-
-const dummyAddress = "0xE54Cd6c3022135d09122ee3f5E05b9b66bed9200";
 
 export const ManageProfileModal = () => {
   const { isOpen, setIsOpen } = useManageProfileModal();
@@ -29,17 +30,36 @@ export const ManageProfileModal = () => {
   const { t } = useTranslation("dappStore");
   const { profile } = useProfileContext();
   const image = profileImages.find((image) => image.src === profile.img?.src);
-
+  const { data: user } = useUserProfile();
   // manage appearence of loader
-  // TODO: check if we have to update it after adding the logic for sign in
   const [loading, setLoading] = useState(false);
+  const queryClient = useQueryClient();
+  const { setIsDropdownOpen } = useWallet();
+
+  const { mutate: changeProfile, isPending } = useMutation({
+    mutationFn: async () => {
+      // TODO:  add event for creating new profile
+      setLoading(true);
+      await signInWithEthereum();
+    },
+
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["user"] });
+      setIsOpen(false);
+      setIsDropdownOpen(true);
+      setLoading(false);
+    },
+
+    onError: () => {
+      setLoading(false);
+    },
+  });
   return (
     <Modal
       isOpen={isOpen}
       setIsOpen={setIsOpen}
       onClose={() => {
         setIsOpen(false);
-        setLoading(false);
       }}
     >
       <Modal.Body>
@@ -65,7 +85,9 @@ export const ManageProfileModal = () => {
               </div>
               <div>
                 <div className="text-base text-heading dark:text-heading-dark">
-                  <AddressDisplay address={address} />
+                  <AddressDisplay
+                    address={user?.defaultWalletAccount.address}
+                  />
                 </div>
                 <div className="text-base text-subheading dark:text-subheading-dark">
                   {t("manageProfile.options.profile.title")}
@@ -86,7 +108,7 @@ export const ManageProfileModal = () => {
               </div>
               <div>
                 <div className="text-base text-heading dark:text-heading-dark">
-                  <AddressDisplay address={dummyAddress} />
+                  <AddressDisplay address={address} />
                 </div>
                 <div className="text-base text-subheading dark:text-subheading-dark">
                   {t("manageProfile.options.wallet.title")}
@@ -99,9 +121,11 @@ export const ManageProfileModal = () => {
               ) : (
                 <Button
                   size="sm"
+                  disabled={
+                    isPending || address === user?.defaultWalletAccount.address
+                  }
                   onClick={() => {
-                    // TODO: add logic for sign in with wallet 1
-                    setLoading(true);
+                    changeProfile();
                   }}
                 >
                   Sign in

--- a/apps/mission/src/components/useSignInWithEthereum.tsx
+++ b/apps/mission/src/components/useSignInWithEthereum.tsx
@@ -1,0 +1,28 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/apps/blob/main/LICENSE)
+
+"use client";
+import { wagmiConfig } from "@evmosapps/evmos-wallet";
+import { signIn } from "next-auth/react";
+import { createSiweMessage } from "@evmosapps/user/auth/create-siwe-message.ts";
+import { getAccount, signMessage } from "wagmi/actions";
+
+// TODO: remove if Renzo already implemented something similar
+export const signInWithEthereum = async () => {
+  const account = getAccount(wagmiConfig);
+  if (!account.address) {
+    throw new Error("No account found");
+  }
+  const message = await createSiweMessage(account.address);
+  const signature = await signMessage(wagmiConfig, {
+    message: message.prepareMessage(),
+    account: account.address,
+  });
+
+  await signIn("credentials", {
+    message: JSON.stringify(message),
+    signature,
+    callbackUrl: window.location.pathname,
+    redirect: false,
+  });
+};

--- a/apps/mission/src/components/warning/mismatch-address.tsx
+++ b/apps/mission/src/components/warning/mismatch-address.tsx
@@ -50,7 +50,7 @@ const MismatchAddressComponent: React.FC = () => {
     } else {
       setAlertVisible(false);
     }
-  }, [address, user]);
+  }, [address, user, profileAddress]);
 
   const manageProfileModal = useManageProfileModal();
   const handleClick = () => {

--- a/apps/mission/src/components/warning/mismatch-address.tsx
+++ b/apps/mission/src/components/warning/mismatch-address.tsx
@@ -9,7 +9,7 @@ import { IconAlertCircle } from "@evmosapps/ui/icons/line/alerts/alert-circle.ts
 import { useTranslation } from "@evmosapps/i18n/client";
 import { useManageProfileModal } from "../header/signin/ManageProfileModal";
 import { useAccount } from "wagmi";
-import { useUserProfile } from "@evmosapps/user/auth/use-user-session.ts";
+import { useUserSession } from "@evmosapps/user/auth/use-user-session.ts";
 
 // Implement withSuspense
 const withSuspense = <P extends JSX.IntrinsicElements["div"]>(
@@ -39,14 +39,12 @@ const MismatchAddressComponent: React.FC = () => {
 
   const { address } = useAccount();
 
-  const { data: user } = useUserProfile();
+  const { data: session } = useUserSession();
 
+  const user = session?.user;
+  const profileAddress = user?.walletAccount[0]?.address;
   useEffect(() => {
-    if (
-      user &&
-      address !== undefined &&
-      address !== user?.defaultWalletAccount.address
-    ) {
+    if (user && address !== undefined && address !== profileAddress) {
       // we only dismiss the alert if the user changes addresses or x'out
       setAlertVisible(true);
     } else {

--- a/apps/mission/src/components/warning/mismatch-address.tsx
+++ b/apps/mission/src/components/warning/mismatch-address.tsx
@@ -9,6 +9,7 @@ import { IconAlertCircle } from "@evmosapps/ui/icons/line/alerts/alert-circle.ts
 import { useTranslation } from "@evmosapps/i18n/client";
 import { useManageProfileModal } from "../header/signin/ManageProfileModal";
 import { useAccount } from "wagmi";
+import { useUserProfile } from "@evmosapps/user/auth/use-user-session.ts";
 
 // Implement withSuspense
 const withSuspense = <P extends JSX.IntrinsicElements["div"]>(
@@ -38,13 +39,20 @@ const MismatchAddressComponent: React.FC = () => {
 
   const { address } = useAccount();
 
+  const { data: user } = useUserProfile();
+
   useEffect(() => {
-    // TODO: compare between the address on the wallet and the one on the profile
-    if (address) {
+    if (
+      user &&
+      address !== undefined &&
+      address !== user?.defaultWalletAccount.address
+    ) {
       // we only dismiss the alert if the user changes addresses or x'out
       setAlertVisible(true);
+    } else {
+      setAlertVisible(false);
     }
-  }, [address]);
+  }, [address, user]);
 
   const manageProfileModal = useManageProfileModal();
   const handleClick = () => {


### PR DESCRIPTION
# 🧙 Description

Add logic for mismatch addresses. 
When you change the address on your wallet extension, it will appear in the ui an alert saying that the addresses from the profile and extension doesn't match. 
If you click on manage profile it will appear a modal with the option to sign in with the address that is on your wallet extension.

Cases that were tested:
- Coinbase
- Metamask
- Keplr
- Trust
- Rabby

Ticket #dapp-182

## ✅ Checklist

- [ ] Acceptance Criteria described in the ticket are met
- [ ] Texts and strings are in the related i18n file
- [ ] Utilities have unit tests
- [ ] User stories and functionalities have integration or e2e tests
- [ ] If adding a new token or network
  - [ ] Registry package is updated
  - [ ] Asset images are added
- [ ] Related packages.json are upgraded
- [ ] Changelog is updated
